### PR TITLE
Call f2py via subprocess.call, install of directly calling main function

### DIFF
--- a/fortranmagic.py
+++ b/fortranmagic.py
@@ -18,6 +18,7 @@ import imp
 import io
 import os
 import sys
+import subprocess
 
 try:
     import hashlib
@@ -167,7 +168,7 @@ class FortranMagics(Magics):
             os.chdir(self._lib_dir)
             try:
                 with capture_output() as captured:
-                    f2py2e.main()
+                    subprocess.call(sys.argv)
                 if show_captured or verbosity > 2:
                     captured()
             except SystemExit as e:


### PR DESCRIPTION
I found that the problems with failing to find the fortran compiler under windows can be resolved by calling the f2py script, rather than directly calling the main() function. I'm not sure why this should fix the problem, perhaps it has something to do with all the environment variables needed to get fortran compilers running under windows.

Fixes #7.