### PR TITLE
Cross compatibility with older NumPy and Python 3

### DIFF
--- a/fortranmagic.py
+++ b/fortranmagic.py
@@ -168,9 +168,12 @@ class FortranMagics(Magics):
         old_cwd = os.getcwdu() if sys.version_info[0] == 2 else os.getcwd()
         try:
             if np.__version__ < LooseVersion('1.10.0'):
-                sys.argv = ['f2py']
+                if sys.version_info[0] >= 3:
+                    sys.argv = ['f2py3']
+                else:
+                    sys.argv = ['f2py']
             else:
-                sys.argv = ['python', '-m', 'numpy.f2py']
+                sys.argv = [sys.executable, '-m', 'numpy.f2py']
             sys.argv += map(str, argv)
 
             if verbosity > 1:

--- a/fortranmagic.py
+++ b/fortranmagic.py
@@ -34,11 +34,14 @@ from IPython.core import display, magic_arguments
 from IPython.utils import py3compat
 from IPython.utils.io import capture_output
 from IPython.utils.path import get_ipython_cache_dir
+import numpy as np
 from numpy.f2py import f2py2e
 from numpy.distutils import fcompiler
 from distutils.core import Distribution
 from distutils.ccompiler import compiler_class
 from distutils.command.build_ext import build_ext
+from distutils.version import LooseVersion
+
 
 __version__ = '0.6.1'
 fcompiler.load_all_fcompiler_classes()
@@ -164,7 +167,12 @@ class FortranMagics(Magics):
         old_argv = sys.argv
         old_cwd = os.getcwdu() if sys.version_info[0] == 2 else os.getcwd()
         try:
-            sys.argv = ['python', '-m', 'numpy.f2py'] + list(map(str, argv))
+            if np.__version__ < LooseVersion('1.10.0'):
+                sys.argv = ['f2py']
+            else:
+                sys.argv = ['python', '-m', 'numpy.f2py']
+            sys.argv += map(str, argv)
+
             if verbosity > 1:
                 print("Running...\n   %s" % ' '.join(sys.argv))
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     license='BSD',
     keywords="ipython notebook fortran f2py science",
     py_modules=['fortranmagic'],
-    install_requires=['ipython', 'numpy>=1.10'],
+    install_requires=['ipython', 'numpy'],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',


### PR DESCRIPTION
NumPy 1.10 is pretty new and not available in most distro packages, so use `f2py3`/`f2py` when it's older. Also, calling `python` does not guarantee the correct result because it's usually a symlink to `python2` (in accordance with the PEP), so compiles still use the wrong version. With `sys.executable`, you'd run with exactly the same interpreter as the notebook kernel is using.

Also, I'm not really sure why it needs to be modifying `sys.argv` since it's `Popen`ing some other process anyway, but I didn't make any changes there as I'm not too sure about it.