### PR TITLE
CI & Tests by `documentation.ipynb`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+*        text=auto
+*.py     text
+*.f      text
+*.ini    text
+*.rst    text
+*.ipynb  text eol=lf
+*.yml    text eol=lf

--- a/.github/workflows/conda-app.yml
+++ b/.github/workflows/conda-app.yml
@@ -70,11 +70,7 @@ jobs:
       - name: Lint with flake8 & ymllint
         run: |
           yamllint .
-          # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # TODO: exit-zero treats all errors as warnings. The GitHub editor is
-          # 127 chars wide : XXX
-          flake8 . --count --exit-zero --max-line-length=127 --statistics
+          flake8 . --count --max-line-length=127 --statistics
 
       - name: Check f2py
         run: |

--- a/.github/workflows/conda-app.yml
+++ b/.github/workflows/conda-app.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Set cache date
         run: echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ${{ matrix.prefix }}
           key:

--- a/.github/workflows/conda-app.yml
+++ b/.github/workflows/conda-app.yml
@@ -1,0 +1,96 @@
+---
+name: Anaconda/jupyter application
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches: ['*']
+
+  pull_request:
+    branches: ['*']
+
+env:
+  CACHE_NUMBER: 1  # increase to reset cache manually
+
+jobs:
+  build:
+
+    strategy:
+      matrix:
+        os: ["macos", "ubuntu", "windows"]
+        include:
+          - os: macos
+            label: osx-64
+            prefix: /Users/runner/miniconda3/envs/my-env
+
+          - os: ubuntu
+            label: linux-64
+            prefix: /usr/share/miniconda3/envs/my-env
+
+          - os: windows
+            label: win-64
+            prefix: C:\Miniconda3\envs\my-env
+
+    name: ${{ matrix.label }}
+    runs-on: ${{ matrix.os }}-latest
+    defaults:
+      run:
+        shell: bash -el {0}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Mambaforge
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          use-mamba: true
+          activate-environment: my-env
+
+      - name: Set cache date
+        run: echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
+
+      - uses: actions/cache@v2
+        with:
+          path: ${{ matrix.prefix }}
+          key:
+            ${{ matrix.label }}-conda-${{
+            hashFiles('test/environment.yml') }}-${{
+            env.DATE }}-${{ env.CACHE_NUMBER }}
+        id: cache
+
+      - name: Update environment
+        run: |
+          sed -e "/#[[:space:]]*only:.*${{ matrix.label }}/p" \
+              -e "/#[[:space:]]*only:/d" \
+              test/environment.yml > environment.yml
+          mamba env update -n my-env -f environment.yml
+        if: steps.cache.outputs.cache-hit != 'true'
+
+      - name: Lint with flake8 & ymllint
+        run: |
+          yamllint .
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # TODO: exit-zero treats all errors as warnings. The GitHub editor is
+          # 127 chars wide : XXX
+          flake8 . --count --exit-zero --max-line-length=127 --statistics
+
+      - name: Check f2py
+        run: |
+          if [ ${{ matrix.os }} == windows ]; then
+            # https://github.com/numpy/numpy/issues/16416
+            # https://github.com/numpy/numpy/pull/20311/files
+            python -m numpy.f2py \
+                --fcompiler=gnu95 --compiler=mingw32 \
+                -c test/fib1.f -m fib1
+          else
+            python -m numpy.f2py -c test/fib1.f -m fib1
+          fi
+          python -c \
+            'import fib1, numpy as np; a=np.zeros(8,"d"); fib1.fib(a); print(a)'
+
+      - name: Test with pytest
+        run: |
+          pytest --cov=fortranmagic --capture=fd
+...

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,11 @@
 *.py[cod]
 
+# jupyter lab/jupyter notebook
+.ipynb_checkpoints/
+
+# vim
+*.swp
+
 # C extensions
 *.so
 

--- a/documentation.ipynb
+++ b/documentation.ipynb
@@ -1,127 +1,246 @@
 {
- "metadata": {
-  "name": "",
-  "signature": "sha256:17bdf0c5bb2dd31488026855c70d1525e93fd8c04cadfb4a35961f6822bc5b7a"
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
+   "cell_type": "markdown",
+   "id": "4d08a29e",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Fortran magic's documentation\n",
+    "\n",
+    "Fortran magic is an [IPython](http://ipython.org) extension that help to use fortran code in an interactive session. \n",
+    "\n",
+    "It adds a `%%fortran` cell magic that compile and import the Fortran code in the cell, using [F2py](http://wiki.scipy.org/F2py).\n",
+    "\n",
+    "The contents of the cell are written to a `.f90` file in the\n",
+    "directory `IPYTHONDIR/fortran` using a filename with the hash of the\n",
+    "code. This file is then compiled. The resulting module\n",
+    "is imported and all of its symbols are injected into the user's\n",
+    "namespace.\n",
+    "\n",
+    "\n",
+    "* Author: Martín Gaitán <gaitan@gmail.com>\n",
+    "* Homepage: https://github.com/mgaitan/fortran_magic \n",
+    "* Twitter: [@tin`_`nqn`_`](https://twitter.com/tin_nqn_)\n",
+    "* License: BSD\n",
+    "\n",
+    "This software was originally sponsored by [Phasety](http://phasety.com)\n",
+    "\n",
+    "Feedback, report of issues and pull requests are welcome!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fe626d66",
+   "metadata": {},
+   "source": [
+    "## Install or upgrade\n",
+    "\n",
+    "You can install or upgrade via `pip`\n",
+    "\n",
+    "        pip install -U fortran-magic\n",
+    "\n",
+    "or install via `conda-forge`\n",
+    "\n",
+    "        conda install -c conda-forge fortran-magic"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "849bb941",
+   "metadata": {},
+   "source": [
+    "# Usage \n",
+    "\n",
+    "Then you are ready to load the magic "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "cb7ec369",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "tags": [
+     "fast"
+    ]
+   },
+   "outputs": [
     {
-     "cell_type": "markdown",
+     "data": {
+      "application/javascript": [
+       "new Promise(function(resolve, reject) {\n",
+       "\tvar script = document.createElement(\"script\");\n",
+       "\tscript.onload = resolve;\n",
+       "\tscript.onerror = reject;\n",
+       "\tscript.src = \"https://raw.github.com/marijnh/CodeMirror/master/mode/fortran/fortran.js\";\n",
+       "\tdocument.head.appendChild(script);\n",
+       "}).then(() => {\n",
+       "IPython.config.cell_magic_highlight['magic_fortran'] = {'reg':[/^%%fortran/]};\n",
+       "});"
+      ]
+     },
      "metadata": {},
-     "source": [
-      "# Fortran magic's documentation\n",
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%load_ext fortranmagic"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c2bcfe5d",
+   "metadata": {},
+   "source": [
+    "To load it each time IPython starts, list it in your configuration file:\n",
+    "\n",
+    "    c.InteractiveShellApp.extensions = [\n",
+    "        'fortranmagic'\n",
+    "    ]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b204c9a5-229e-4f54-a86b-3540869ef44c",
+   "metadata": {
+    "tags": [
+     "fast",
+     "random"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import platform\n",
+    "\n",
+    "if platform.system() == 'Windows':\n",
+    "        # Depends of system, python builds, and compilers compatibility.\n",
+    "        # See below.\n",
+    "    f_config = \"--fcompiler=gnu95 --compiler=mingw32\"\n",
+    "else:\n",
+    "        # For Unix, compilers are usually more compatible.\n",
+    "    f_config = \"\"\n",
+    "%fortran_config {f_config}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "db4d6f87",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Basic example\n",
+    "\n",
+    "Just mark the cell with `%%fortran` in the first line. The code will be highlighted accordingly and compiled when the cell is run "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "edddd3c0",
+   "metadata": {
+    "tags": [
+     "fast"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "%%fortran\n",
+    "\n",
+    "subroutine f1(x, y, z)\n",
+    "    real, intent(in) :: x,y\n",
+    "    real, intent(out) :: z\n",
+    "\n",
+    "    z = sin(x+y)\n",
+    "\n",
+    "end subroutine f1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "05f82b33",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "tags": [
+     "fast"
+    ]
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "9.265740664e-05"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%precision %.10g\n",
+    "f1(1.0, 2.1415)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "fea5599d",
+   "metadata": {
+    "tags": [
+     "fast"
+    ]
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "z = f1(x,y)\n",
       "\n",
-      "Fortran magic is an [IPython](http://ipython.org) extension that help to use fortran code in an interactive session. \n",
+      "Wrapper for ``f1``.\n",
       "\n",
-      "It adds a `%%fortran` cell magic that compile and import the Fortran code in the cell, using [F2py](http://wiki.scipy.org/F2py).\n",
+      "Parameters\n",
+      "----------\n",
+      "x : input float\n",
+      "y : input float\n",
       "\n",
-      "The contents of the cell are written to a `.f90` file in the\n",
-      "directory `IPYTHONDIR/fortran` using a filename with the hash of the\n",
-      "code. This file is then compiled. The resulting module\n",
-      "is imported and all of its symbols are injected into the user's\n",
-      "namespace.\n",
-      "\n",
-      "\n",
-      "* Author: Mart\u00edn Gait\u00e1n <gaitan@gmail.com>\n",
-      "* Homepage: https://github.com/mgaitan/fortran_magic \n",
-      "* Twitter: [@tin`_`nqn`_`](https://twitter.com/tin_nqn_)\n",
-      "* License: BSD\n",
-      "\n",
-      "This software was originally sponsored by [Phasety](http://phasety.com)\n",
-      "\n",
-      "Feedback, report of issues and pull requests are welcome!"
+      "Returns\n",
+      "-------\n",
+      "z : float\n",
+      "\n"
      ]
-    },
+    }
+   ],
+   "source": [
+    "print(f1.__doc__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "0b155099-12b3-451d-b8cc-e6f4e6971226",
+   "metadata": {
+    "tags": [
+     "fast"
+    ]
+   },
+   "outputs": [
     {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "## Install or upgrade\n",
-      "\n",
-      "You can install or upgrade via `pip`\n",
-      "\n",
-      "        pip install -U fortran-magic\n",
-      "\n",
-      "or directly from the repository using `%install_ext` magic command."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "%install_ext https://raw.github.com/mgaitan/fortran_magic/master/fortranmagic.py"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "Installed fortranmagic.py. To use it, type:\n",
-        "  %load_ext fortranmagic\n"
-       ]
-      }
-     ],
-     "prompt_number": 1
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "# Usage \n",
-      "\n",
-      "Then you are ready to load the magic "
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "%load_ext fortranmagic"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "javascript": [
-        "$.getScript(\"https://raw.github.com/marijnh/CodeMirror/master/mode/fortran/fortran.js\", function () {\n",
-        "IPython.config.cell_magic_highlight['magic_fortran'] = {'reg':[/^%%fortran/]};});\n"
-       ],
-       "metadata": {},
-       "output_type": "display_data"
-      }
-     ],
-     "prompt_number": 2
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "To load it each time IPython starts, list it in your configuration file:\n",
-      "\n",
-      "    c.InteractiveShellApp.extensions = [\n",
-      "        'fortranmagic'\n",
-      "    ]"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "## Basic example\n",
-      "\n",
-      "Just mark the cell with `%%fortran` in the first line. The code will be highlighted accordingly and compiled when the cell is run "
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "%%fortran\n",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "\n",
       "subroutine f1(x, y, z)\n",
       "    real, intent(in) :: x,y\n",
@@ -129,773 +248,660 @@
       "\n",
       "    z = sin(x+y)\n",
       "\n",
-      "end subroutine f1"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 3
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "f1(1.0, 2.1415)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 4,
-       "text": [
-        "9.26574066397734e-05"
-       ]
-      }
-     ],
-     "prompt_number": 4
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "print f1.__doc__"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "f1 - Function signature:\n",
-        "  z = f1(x,y)\n",
-        "Required arguments:\n",
-        "  x : input float\n",
-        "  y : input float\n",
-        "Return objects:\n",
-        "  z : float\n",
-        "\n"
-       ]
-      }
-     ],
-     "prompt_number": 5
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "## Verbosity\n",
-      "\n",
-      "By default the magic only returns output when the compilation process fails. But you can increase the verbosity with the flag `-v`"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "%%fortran -v \n",
-      "\n",
-      "module hi\n",
-      "  integer :: five = 5\n",
-      "end module   "
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "\n",
-        "Ok. The following fortran objects are ready to use: hi\n"
-       ]
-      }
-     ],
-     "prompt_number": 6
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "%%fortran -vv \n",
-      "\n",
-      "module hi\n",
-      "  integer :: five = 5\n",
-      "end module   "
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "Running...\n",
-        "   f2py -m _fortran_magic_c3329f973fb44fd5c93af2960628c6b6 -c /home/tin/.cache/ipython/fortran/_fortran_magic_c3329f973fb44fd5c93af2960628c6b6.f90\n",
-        "\n",
-        "Ok. The following fortran objects are ready to use: hi"
-       ]
-      },
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "\n"
-       ]
-      }
-     ],
-     "prompt_number": 7
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "%%fortran -vvv\n",
-      "\n",
-      "module hi\n",
-      "  integer :: five = 5\n",
-      "end module   "
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "Running...\n",
-        "   f2py -m _fortran_magic_c3329f973fb44fd5c93af2960628c6b6 -c /home/tin/.cache/ipython/fortran/_fortran_magic_c3329f973fb44fd5c93af2960628c6b6.f90\n",
-        "running build\n",
-        "running config_cc\n",
-        "unifing config_cc, config, build_clib, build_ext, build commands --compiler options\n",
-        "running config_fc\n",
-        "unifing config_fc, config, build_clib, build_ext, build commands --fcompiler options\n",
-        "running build_src\n",
-        "build_src\n",
-        "building extension \"_fortran_magic_c3329f973fb44fd5c93af2960628c6b6\" sources\n",
-        "f2py options: []\n",
-        "f2py:> /tmp/tmpN1POpo/src.linux-x86_64-2.7/_fortran_magic_c3329f973fb44fd5c93af2960628c6b6module.c\n",
-        "creating /tmp/tmpN1POpo\n",
-        "creating /tmp/tmpN1POpo/src.linux-x86_64-2.7\n",
-        "Reading fortran codes...\n",
-        "\tReading file '/home/tin/.cache/ipython/fortran/_fortran_magic_c3329f973fb44fd5c93af2960628c6b6.f90' (format:free)\n",
-        "Post-processing...\n",
-        "\tBlock: _fortran_magic_c3329f973fb44fd5c93af2960628c6b6\n",
-        "\t\t\tBlock: hi\n",
-        "Post-processing (stage 2)...\n",
-        "\tBlock: _fortran_magic_c3329f973fb44fd5c93af2960628c6b6\n",
-        "\t\tBlock: unknown_interface\n",
-        "\t\t\tBlock: hi\n",
-        "Building modules...\n",
-        "\tBuilding module \"_fortran_magic_c3329f973fb44fd5c93af2960628c6b6\"...\n",
-        "\t\tConstructing F90 module support for \"hi\"...\n",
-        "\t\t  Variables: five\n",
-        "\tWrote C/API module \"_fortran_magic_c3329f973fb44fd5c93af2960628c6b6\" to file \"/tmp/tmpN1POpo/src.linux-x86_64-2.7/_fortran_magic_c3329f973fb44fd5c93af2960628c6b6module.c\"\n",
-        "\tFortran 90 wrappers are saved to \"/tmp/tmpN1POpo/src.linux-x86_64-2.7/_fortran_magic_c3329f973fb44fd5c93af2960628c6b6-f2pywrappers2.f90\"\n",
-        "  adding '/tmp/tmpN1POpo/src.linux-x86_64-2.7/fortranobject.c' to sources.\n",
-        "  adding '/tmp/tmpN1POpo/src.linux-x86_64-2.7' to include_dirs.\n",
-        "copying /usr/lib/python2.7/dist-packages/numpy/f2py/src/fortranobject.c -> /tmp/tmpN1POpo/src.linux-x86_64-2.7\n",
-        "copying /usr/lib/python2.7/dist-packages/numpy/f2py/src/fortranobject.h -> /tmp/tmpN1POpo/src.linux-x86_64-2.7\n",
-        "  adding '/tmp/tmpN1POpo/src.linux-x86_64-2.7/_fortran_magic_c3329f973fb44fd5c93af2960628c6b6-f2pywrappers2.f90' to sources.\n",
-        "build_src: building npy-pkg config files\n",
-        "running build_ext\n",
-        "customize UnixCCompiler\n",
-        "customize UnixCCompiler using build_ext\n",
-        "customize GnuFCompiler\n",
-        "customize IntelFCompiler\n",
-        "customize LaheyFCompiler\n",
-        "customize PGroupFCompiler\n",
-        "customize AbsoftFCompiler\n",
-        "customize NAGFCompiler\n",
-        "customize VastFCompiler\n",
-        "customize CompaqFCompiler\n",
-        "customize IntelItaniumFCompiler\n",
-        "customize IntelEM64TFCompiler\n",
-        "customize Gnu95FCompiler\n",
-        "customize Gnu95FCompiler\n",
-        "customize Gnu95FCompiler using build_ext\n",
-        "running scons\n",
-        "Removing build directory /tmp/tmpN1POpo\n"
-       ]
-      },
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "\n",
-        "Ok. The following fortran objects are ready to use: hi\n"
-       ]
-      }
-     ],
-     "prompt_number": 8
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "## Using f2py options\n",
-      "\n",
-      "Almost all f2py's command line options are exposed to the `%%fortran` cell magic. See the docstring for detail. For example:"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "%%fortran --fcompiler gnu95 --compiler unix --f90flags \"-d\" --noarch\n",
-      "C\n",
-      "      SUBROUTINE ZADD(A,B,C,N)\n",
-      "C\n",
-      "      DOUBLE COMPLEX A(*)\n",
-      "      DOUBLE COMPLEX B(*)\n",
-      "      DOUBLE COMPLEX C(*)\n",
-      "      INTEGER N\n",
-      "      DO 20 J = 1, N\n",
-      "         C(J) = A(J)+B(J)\n",
-      " 20   CONTINUE\n",
-      "      END\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 9
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "print(zadd.__doc__)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "zadd - Function signature:\n",
-        "  zadd(a,b,c,n)\n",
-        "Required arguments:\n",
-        "  a : input rank-1 array('D') with bounds (*)\n",
-        "  b : input rank-1 array('D') with bounds (*)\n",
-        "  c : input rank-1 array('D') with bounds (*)\n",
-        "  n : input int\n",
-        "\n"
-       ]
-      }
-     ],
-     "prompt_number": 10
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "## Linking resources\n",
-      "\n",
-      "Use `--link` option. This is `--link-<resource>` in f2py command line"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "%%fortran --link lapack -vv\n",
-      "\n",
-      "subroutine solve(A, b, x, n)\n",
-      "    ! solve the matrix equation A*x=b using LAPACK\n",
-      "    implicit none\n",
-      "\n",
-      "    real*8, dimension(n,n), intent(in) :: A\n",
-      "    real*8, dimension(n), intent(in) :: b\n",
-      "    real*8, dimension(n), intent(out) :: x\n",
-      "\n",
-      "    integer :: i, j, pivot(n), ok\n",
-      "\n",
-      "    integer, intent(in) :: n\n",
-      "    x = b\n",
-      "\n",
-      "    ! find the solution using the LAPACK routine SGESV\n",
-      "    call DGESV(n, 1, A, n, pivot, x, n, ok)\n",
-      "    \n",
-      "end subroutine"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "Running...\n",
-        "   f2py --link-lapack -m _fortran_magic_d701894e5f0a207987075cc0cf8efa4f -c /home/tin/.cache/ipython/fortran/_fortran_magic_d701894e5f0a207987075cc0cf8efa4f.f90\n",
-        "\n",
-        "Ok. The following fortran objects are ready to use: solve"
-       ]
-      },
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "\n"
-       ]
-      }
-     ],
-     "prompt_number": 5
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "import numpy as np\n",
-      "A = np.array([[1, 2.5], [-3, 4]])\n",
-      "b = np.array([1, 2.5])"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 6
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "solve?"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 8
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Which is, by the way, the same than"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "np.linalg.solve(A, b)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 14,
-       "text": [
-        "array([-0.19565217,  0.47826087])"
-       ]
-      }
-     ],
-     "prompt_number": 14
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "## Extra arguments\n",
-      "\n",
-      "F2py could have many other arguments. You could append extra arguments with `--extra`. For example:\n",
-      "\n",
-      "\n",
-      "      %%fortran --extra '-L/path/to/open/ -lopenblas'\n",
-      "      \n",
-      "      %%fortran --extra '-D<define> -U<name>'\n",
-      "   \n",
-      "      %%fortran --extra '-DPREPEND_FORTRAN -DUPPERCASE_FORTRAN'\n",
-      "      \n",
-      "The option `--extra` could be given multiple times."
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "## Save options\n",
-      "\n",
-      "By default, `%%fortran` call to `f2py` without parameters (except, of course, the `-m` and `-c` needed to compile a new module). You can change this behaviour with `%fortran_config`. This line magic can be used in three different ways:\n",
-      "\n",
-      "\n",
-      "    %fortran_config\n",
-      "\n",
-      "        Show the current custom configuration\n",
-      "\n",
-      "    %fortran_config --defaults\n",
-      "\n",
-      "        Delete the current configuration and back to defaults\n",
-      "\n",
-      "    %fortran_config <other options>\n",
-      "\n",
-      "        Save (persitently) <other options> to use with %%fortran. The same arguments allowed for `%%fortran` are available\n",
-      "        \n",
-      "For example, to set the highest verbose level (`-vvv`) and `gnu95` as default `--fcompiler`:"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "%fortran_config -vvv --fcompiler gnu95"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "New default arguments for %fortran:\n",
-        "\t-vvv --fcompiler gnu95\n"
-       ]
-      }
-     ],
-     "prompt_number": 15
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Now the use of `%%fortran` will include `-vvv --fcompiler gnu95` implicitly"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "%%fortran\n",
-      "\n",
-      "module hi\n",
-      "  integer :: five = 5\n",
-      "end module   "
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "Running...\n",
-        "   f2py --fcompiler=gnu95 -m _fortran_magic_c3329f973fb44fd5c93af2960628c6b6 -c /home/tin/.cache/ipython/fortran/_fortran_magic_c3329f973fb44fd5c93af2960628c6b6.f90\n",
-        "running build\n",
-        "running config_cc\n",
-        "unifing config_cc, config, build_clib, build_ext, build commands --compiler options\n",
-        "running config_fc\n",
-        "unifing config_fc, config, build_clib, build_ext, build commands --fcompiler options\n",
-        "running build_src\n",
-        "build_src\n",
-        "building extension \"_fortran_magic_c3329f973fb44fd5c93af2960628c6b6\" sources\n",
-        "f2py options: []\n",
-        "f2py:> /tmp/tmpLAigrv/src.linux-x86_64-2.7/_fortran_magic_c3329f973fb44fd5c93af2960628c6b6module.c\n",
-        "creating /tmp/tmpLAigrv\n",
-        "creating /tmp/tmpLAigrv/src.linux-x86_64-2.7\n",
-        "Reading fortran codes...\n",
-        "\tReading file '/home/tin/.cache/ipython/fortran/_fortran_magic_c3329f973fb44fd5c93af2960628c6b6.f90' (format:free)\n",
-        "Post-processing...\n",
-        "\tBlock: _fortran_magic_c3329f973fb44fd5c93af2960628c6b6\n",
-        "\t\t\tBlock: hi\n",
-        "Post-processing (stage 2)...\n",
-        "\tBlock: _fortran_magic_c3329f973fb44fd5c93af2960628c6b6\n",
-        "\t\tBlock: unknown_interface\n",
-        "\t\t\tBlock: hi\n",
-        "Building modules...\n",
-        "\tBuilding module \"_fortran_magic_c3329f973fb44fd5c93af2960628c6b6\"...\n",
-        "\t\tConstructing F90 module support for \"hi\"...\n",
-        "\t\t  Variables: five\n",
-        "\tWrote C/API module \"_fortran_magic_c3329f973fb44fd5c93af2960628c6b6\" to file \"/tmp/tmpLAigrv/src.linux-x86_64-2.7/_fortran_magic_c3329f973fb44fd5c93af2960628c6b6module.c\"\n",
-        "\tFortran 90 wrappers are saved to \"/tmp/tmpLAigrv/src.linux-x86_64-2.7/_fortran_magic_c3329f973fb44fd5c93af2960628c6b6-f2pywrappers2.f90\"\n",
-        "  adding '/tmp/tmpLAigrv/src.linux-x86_64-2.7/fortranobject.c' to sources.\n",
-        "  adding '/tmp/tmpLAigrv/src.linux-x86_64-2.7' to include_dirs.\n",
-        "copying /usr/lib/python2.7/dist-packages/numpy/f2py/src/fortranobject.c -> /tmp/tmpLAigrv/src.linux-x86_64-2.7\n",
-        "copying /usr/lib/python2.7/dist-packages/numpy/f2py/src/fortranobject.h -> /tmp/tmpLAigrv/src.linux-x86_64-2.7\n",
-        "  adding '/tmp/tmpLAigrv/src.linux-x86_64-2.7/_fortran_magic_c3329f973fb44fd5c93af2960628c6b6-f2pywrappers2.f90' to sources.\n",
-        "build_src: building npy-pkg config files\n",
-        "running build_ext\n",
-        "customize UnixCCompiler\n",
-        "customize UnixCCompiler using build_ext\n",
-        "customize Gnu95FCompiler\n",
-        "customize Gnu95FCompiler using build_ext\n",
-        "building '_fortran_magic_c3329f973fb44fd5c93af2960628c6b6' extension\n",
-        "compiling C sources\n",
-        "C compiler: gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC\n",
-        "\n",
-        "creating /tmp/tmpLAigrv/tmp\n",
-        "creating /tmp/tmpLAigrv/tmp/tmpLAigrv\n",
-        "creating /tmp/tmpLAigrv/tmp/tmpLAigrv/src.linux-x86_64-2.7\n",
-        "compile options: '-I/tmp/tmpLAigrv/src.linux-x86_64-2.7 -I/usr/lib/python2.7/dist-packages/numpy/core/include -I/usr/include/python2.7 -c'\n",
-        "gcc: /tmp/tmpLAigrv/src.linux-x86_64-2.7/_fortran_magic_c3329f973fb44fd5c93af2960628c6b6module.c\n",
-        "gcc: /tmp/tmpLAigrv/src.linux-x86_64-2.7/fortranobject.c\n",
-        "compiling Fortran 90 module sources\n",
-        "Fortran f77 compiler: /usr/bin/gfortran -Wall -ffixed-form -fno-second-underscore -fPIC -O3 -funroll-loops\n",
-        "Fortran f90 compiler: /usr/bin/gfortran -Wall -fno-second-underscore -fPIC -O3 -funroll-loops\n",
-        "Fortran fix compiler: /usr/bin/gfortran -Wall -ffixed-form -fno-second-underscore -Wall -fno-second-underscore -fPIC -O3 -funroll-loops\n",
-        "creating /tmp/tmpLAigrv/home\n",
-        "creating /tmp/tmpLAigrv/home/tin\n",
-        "creating /tmp/tmpLAigrv/home/tin/.cache\n",
-        "creating /tmp/tmpLAigrv/home/tin/.cache/ipython\n",
-        "creating /tmp/tmpLAigrv/home/tin/.cache/ipython/fortran\n",
-        "compile options: '-I/tmp/tmpLAigrv/src.linux-x86_64-2.7 -I/usr/lib/python2.7/dist-packages/numpy/core/include -I/usr/include/python2.7 -c'\n",
-        "extra options: '-J/tmp/tmpLAigrv/ -I/tmp/tmpLAigrv/'\n",
-        "gfortran:f90: /home/tin/.cache/ipython/fortran/_fortran_magic_c3329f973fb44fd5c93af2960628c6b6.f90\n",
-        "compiling Fortran sources\n",
-        "Fortran f77 compiler: /usr/bin/gfortran -Wall -ffixed-form -fno-second-underscore -fPIC -O3 -funroll-loops\n",
-        "Fortran f90 compiler: /usr/bin/gfortran -Wall -fno-second-underscore -fPIC -O3 -funroll-loops\n",
-        "Fortran fix compiler: /usr/bin/gfortran -Wall -ffixed-form -fno-second-underscore -Wall -fno-second-underscore -fPIC -O3 -funroll-loops\n",
-        "compile options: '-I/tmp/tmpLAigrv/src.linux-x86_64-2.7 -I/usr/lib/python2.7/dist-packages/numpy/core/include -I/usr/include/python2.7 -c'\n",
-        "extra options: '-J/tmp/tmpLAigrv/ -I/tmp/tmpLAigrv/'\n",
-        "gfortran:f90: /tmp/tmpLAigrv/src.linux-x86_64-2.7/_fortran_magic_c3329f973fb44fd5c93af2960628c6b6-f2pywrappers2.f90\n",
-        "/usr/bin/gfortran -Wall -Wall -shared /tmp/tmpLAigrv/tmp/tmpLAigrv/src.linux-x86_64-2.7/_fortran_magic_c3329f973fb44fd5c93af2960628c6b6module.o /tmp/tmpLAigrv/tmp/tmpLAigrv/src.linux-x86_64-2.7/fortranobject.o /tmp/tmpLAigrv/home/tin/.cache/ipython/fortran/_fortran_magic_c3329f973fb44fd5c93af2960628c6b6.o /tmp/tmpLAigrv/tmp/tmpLAigrv/src.linux-x86_64-2.7/_fortran_magic_c3329f973fb44fd5c93af2960628c6b6-f2pywrappers2.o -lgfortran -o ./_fortran_magic_c3329f973fb44fd5c93af2960628c6b6.so\n",
-        "running scons\n",
-        "Removing build directory /tmp/tmpLAigrv\n"
-       ]
-      },
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "\n",
-        "Ok. The following fortran objects are ready to use: hi\n"
-       ]
-      }
-     ],
-     "prompt_number": 16
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "We can see whatever the default config has"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "%fortran_config"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "Current defaults arguments for %fortran:\n",
-        "\t-vvv --fcompiler gnu95\n"
-       ]
-      }
-     ],
-     "prompt_number": 17
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "You can override that global configuration for one specific cell. For example, `%%fortran -vv` will change the the verbose level but still use `--fcompiler gnu95`"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "%%fortran -vv\n",
-      "\n",
-      "module hi\n",
-      "  integer :: five = 5\n",
-      "end module   "
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "Running...\n",
-        "   f2py --fcompiler=gnu95 -m _fortran_magic_c3329f973fb44fd5c93af2960628c6b6 -c /home/tin/.cache/ipython/fortran/_fortran_magic_c3329f973fb44fd5c93af2960628c6b6.f90\n",
-        "\n",
-        "Ok. The following fortran objects are ready to use: hi"
-       ]
-      },
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "\n"
-       ]
-      }
-     ],
-     "prompt_number": 18
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "To clear the custom defaults and back to the defaults (no arguments) use:"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "%fortran_config --defaults"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "Deleted custom config. Back to default arguments for %%fortran\n"
-       ]
-      }
-     ],
-     "prompt_number": 19
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "## Help on f2py \n",
-      "\n",
-      "F2py has some flag that output help. See the docstring of `%f2py_help`"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "%f2py_help --link blas"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "blas_info:\n",
-        "  libraries blas not found in /usr/local/lib\n",
-        "  libraries blas not found in /usr/lib64\n",
-        "  FOUND:\n",
-        "    libraries = ['blas']\n",
-        "    library_dirs = ['/usr/lib']\n",
-        "    language = f77\n",
-        "\n"
-       ]
-      }
-     ],
-     "prompt_number": 20
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "%f2py_help --fcompiler"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "Gnu95FCompiler instance properties:\n",
-        "  archiver        = ['/usr/bin/gfortran', '-cr']\n",
-        "  compile_switch  = '-c'\n",
-        "  compiler_f77    = ['/usr/bin/gfortran', '-Wall', '-ffixed-form', '-fno-\n",
-        "                    second-underscore', '-fPIC', '-O3', '-funroll-loops']\n",
-        "  compiler_f90    = ['/usr/bin/gfortran', '-Wall', '-fno-second-underscore',\n",
-        "                    '-fPIC', '-O3', '-funroll-loops']\n",
-        "  compiler_fix    = ['/usr/bin/gfortran', '-Wall', '-ffixed-form', '-fno-\n",
-        "                    second-underscore', '-Wall', '-fno-second-underscore', '-\n",
-        "                    fPIC', '-O3', '-funroll-loops']\n",
-        "  libraries       = ['gfortran']\n",
-        "  library_dirs    = []\n",
-        "  linker_exe      = ['/usr/bin/gfortran', '-Wall', '-Wall']\n",
-        "  linker_so       = ['/usr/bin/gfortran', '-Wall', '-Wall', '-shared']\n",
-        "  object_switch   = '-o '\n",
-        "  ranlib          = ['/usr/bin/gfortran']\n",
-        "  version         = LooseVersion ('4.7.2-2')\n",
-        "  version_cmd     = ['/usr/bin/gfortran', '--version']\n",
-        "Fortran compilers found:\n",
-        "  --fcompiler=gnu95  GNU Fortran 95 compiler (4.7.2-2)\n",
-        "Compilers available for this platform, but not found:\n",
-        "  --fcompiler=absoft   Absoft Corp Fortran Compiler\n",
-        "  --fcompiler=compaq   Compaq Fortran Compiler\n",
-        "  --fcompiler=g95      G95 Fortran Compiler\n",
-        "  --fcompiler=gnu      GNU Fortran 77 compiler\n",
-        "  --fcompiler=intel    Intel Fortran Compiler for 32-bit apps\n",
-        "  --fcompiler=intele   Intel Fortran Compiler for Itanium apps\n",
-        "  --fcompiler=intelem  Intel Fortran Compiler for 64-bit apps\n",
-        "  --fcompiler=lahey    Lahey/Fujitsu Fortran 95 Compiler\n",
-        "  --fcompiler=nag      NAGWare Fortran 95 Compiler\n",
-        "  --fcompiler=pathf95  PathScale Fortran Compiler\n",
-        "  --fcompiler=pg       Portland Group Fortran Compiler\n",
-        "  --fcompiler=vast     Pacific-Sierra Research Fortran 90 Compiler\n",
-        "Compilers not available on this platform:\n",
-        "  --fcompiler=hpux      HP Fortran 90 Compiler\n",
-        "  --fcompiler=ibm       IBM XL Fortran Compiler\n",
-        "  --fcompiler=intelev   Intel Visual Fortran Compiler for Itanium apps\n",
-        "  --fcompiler=intelv    Intel Visual Fortran Compiler for 32-bit apps\n",
-        "  --fcompiler=intelvem  Intel Visual Fortran Compiler for 64-bit apps\n",
-        "  --fcompiler=mips      MIPSpro Fortran Compiler\n",
-        "  --fcompiler=none      Fake Fortran compiler\n",
-        "  --fcompiler=sun       Sun or Forte Fortran 95 Compiler\n",
-        "For compiler details, run 'config_fc --verbose' setup command.\n"
-       ]
-      }
-     ],
-     "prompt_number": 21
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "%f2py_help --compiler"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "List of available compilers:\n",
-        "  --compiler=bcpp     Borland C++ Compiler\n",
-        "  --compiler=cygwin   Cygwin port of GNU C Compiler for Win32\n",
-        "  --compiler=emx      EMX port of GNU C Compiler for OS/2\n",
-        "  --compiler=intel    Intel C Compiler for 32-bit applications\n",
-        "  --compiler=intele   Intel C Itanium Compiler for Itanium-based applications\n",
-        "  --compiler=intelem  Intel C Compiler for 64-bit applications\n",
-        "  --compiler=mingw32  Mingw32 port of GNU C Compiler for Win32\n",
-        "  --compiler=msvc     Microsoft Visual C++\n",
-        "  --compiler=pathcc   PathScale Compiler for SiCortex-based applications\n",
-        "  --compiler=unix     standard UNIX-style compiler\n"
-       ]
-      }
-     ],
-     "prompt_number": 22
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "---------------\n",
-      "\n",
-      "* Bugs? Ideas? [Open an issue](https://github.com/mgaitan/fortran_magic)\n",
-      "* Do you want to collaborate? [Fork it](https://github.com/mgaitan/fortran_magic/fork)! and send a pull-request"
+      "end subroutine f1\n",
+      "\n"
      ]
     }
    ],
-   "metadata": {}
+   "source": [
+    "print(f1.__source__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fb0aa568",
+   "metadata": {},
+   "source": [
+    "## Verbosity\n",
+    "\n",
+    "By default the magic only returns output when the compilation process fails. But you can increase the verbosity with the flag `-v`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "0c0d794b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Ok. The following fortran objects are ready to use: hi\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%fortran -v \n",
+    "\n",
+    "module hi\n",
+    "  integer :: five = 5\n",
+    "end module   "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1c75b752",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "tags": [
+     "random"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "%%fortran -vv \n",
+    "\n",
+    "module hi\n",
+    "  integer :: five = 5\n",
+    "end module   "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "228e92af",
+   "metadata": {
+    "tags": [
+     "random",
+     "slow"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "%%fortran -vvv\n",
+    "\n",
+    "module hi\n",
+    "  integer :: five = 5\n",
+    "end module   "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b39c4fe4",
+   "metadata": {},
+   "source": [
+    "## Using f2py options\n",
+    "\n",
+    "Almost all f2py's command line options are exposed to the `%%fortran` cell magic. See the docstring for detail. For example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "2d4750df",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Ok. The following fortran objects are ready to use: zadd\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%fortran -v --f77flags=\"-ffixed-form\" --noarch\n",
+    "C\n",
+    "      SUBROUTINE ZADD(A,B,C,N)\n",
+    "C\n",
+    "      DOUBLE COMPLEX A(*)\n",
+    "      DOUBLE COMPLEX B(*)\n",
+    "      DOUBLE COMPLEX C(*)\n",
+    "      INTEGER N\n",
+    "      DO 20 J = 1, N\n",
+    "         C(J) = A(J)+B(J)\n",
+    " 20   CONTINUE\n",
+    "      END"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "88eb2644",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "zadd(a,b,c,n)\n",
+      "\n",
+      "Wrapper for ``zadd``.\n",
+      "\n",
+      "Parameters\n",
+      "----------\n",
+      "a : input rank-1 array('D') with bounds (*)\n",
+      "b : input rank-1 array('D') with bounds (*)\n",
+      "c : input rank-1 array('D') with bounds (*)\n",
+      "n : input int\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(zadd.__doc__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "3e40e3d4-e2c5-4398-97ac-f6eaaa7531b3",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[0.+0.j 1.+1.j 2.+2.j 3.+3.j 4.+4.j 5.+5.j 6.+6.j 7.+7.j 8.+8.j 9.+9.j]\n"
+     ]
+    }
+   ],
+   "source": [
+    "a = np.arange(10, dtype=np.cdouble)\n",
+    "b = a*complex(0, 1)\n",
+    "c = np.empty_like(a)\n",
+    "zadd(a, b, c, len(c))\n",
+    "print(c)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f834854f",
+   "metadata": {},
+   "source": [
+    "## Linking resources\n",
+    "\n",
+    "Use `--link` option. This is `--link-<resource>` in f2py command line"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bd257b84",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "tags": [
+     "random"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "%%fortran --link lapack -vv\n",
+    "\n",
+    "subroutine solve(A, b, x, n)\n",
+    "    ! solve the matrix equation A*x=b using LAPACK\n",
+    "    implicit none\n",
+    "\n",
+    "    real*8, dimension(n,n), intent(in) :: A\n",
+    "    real*8, dimension(n), intent(in) :: b\n",
+    "    real*8, dimension(n), intent(out) :: x\n",
+    "\n",
+    "    integer :: i, j, pivot(n), ok\n",
+    "\n",
+    "    integer, intent(in) :: n\n",
+    "    x = b\n",
+    "\n",
+    "    ! find the solution using the LAPACK routine SGESV\n",
+    "    call DGESV(n, 1, A, n, pivot, x, n, ok)\n",
+    "    \n",
+    "end subroutine"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "385be515",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "A = np.array([[1, 2.5], [-3, 4]])\n",
+    "b = np.array([1, 2.5])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "94ff10f7",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "x = solve(a,b,[n])\n",
+      "\n",
+      "Wrapper for ``solve``.\n",
+      "\n",
+      "Parameters\n",
+      "----------\n",
+      "a : input rank-2 array('d') with bounds (n,n)\n",
+      "b : input rank-1 array('d') with bounds (n)\n",
+      "\n",
+      "Other Parameters\n",
+      "----------------\n",
+      "n : input int, optional\n",
+      "    Default: shape(a, 0)\n",
+      "\n",
+      "Returns\n",
+      "-------\n",
+      "x : rank-1 array('d') with bounds (n)\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(solve.__doc__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be6d669e",
+   "metadata": {},
+   "source": [
+    "Which is, by the way, the same than"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "67c73007",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([-0.19565217,  0.47826087])"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "x = np.linalg.solve(A, b)\n",
+    "x"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "1fcd6beb-ffad-4787-90fc-683850018b66",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "np.testing.assert_allclose(x, solve(A, b))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "368d33d9",
+   "metadata": {},
+   "source": [
+    "## Extra arguments\n",
+    "\n",
+    "F2py could have many other arguments. You could append extra arguments with `--extra`. For example:\n",
+    "\n",
+    "\n",
+    "      %%fortran --extra '-L/path/to/open/ -lopenblas'\n",
+    "      \n",
+    "      %%fortran --extra '-D<define> -U<name>'\n",
+    "   \n",
+    "      %%fortran --extra '-DPREPEND_FORTRAN -DUPPERCASE_FORTRAN'\n",
+    "      \n",
+    "The option `--extra` could be given multiple times."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bd784372-1533-4713-ab7e-7fc1e1116fe4",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Compilers runtime compatibility\n",
+    "\n",
+    "Incompatibility of compilers or runtime libraries that python was built with, and which are used to build the python extension, can lead to errors during build and/or errors in loading the resulting python extension module.\n",
+    "\n",
+    "For example, at the moment, Visual Studio compiler and GNU Fortran (`gfortran`, formerly `g95`) are not compatible when used with `numpy.f2py`. GNU Fortran is compatible with the mingw32 compiler (32-bit or 64-bit), which is available in `conda-forge` or `MSYS2`.\n",
+    "\n",
+    "Detailed description see:\n",
+    "- Numpy issue [Can't import module created by f2py \"ImportError: DLL load failed\" #16416](https://github.com/numpy/numpy/issues/16416#issue-626668211) ;\n",
+    "- Numpy documentation PR [DOC: Windows and F2PY #20311](https://github.com/numpy/numpy/pull/20311/files) ."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "82842bda",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Save options\n",
+    "\n",
+    "By default, `%%fortran` call to `f2py` without parameters (except, of course, the `-m` and `-c` needed to compile a new module). You can change this behaviour with `%fortran_config`. This line magic can be used in three different ways:\n",
+    "\n",
+    "\n",
+    "    %fortran_config\n",
+    "\n",
+    "        Show the current custom configuration\n",
+    "\n",
+    "    %fortran_config --defaults\n",
+    "\n",
+    "        Delete the current configuration and back to defaults\n",
+    "\n",
+    "    %fortran_config <other options>\n",
+    "\n",
+    "        Save (persitently) <other options> to use with %%fortran. The same arguments allowed for `%%fortran` are available\n",
+    "        \n",
+    "For example, to set the highest verbose level (`-vvv`) and `gnu95` as default `--fcompiler`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "3786a402",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "New default arguments for %fortran:\n",
+      "\t-vvv --fcompiler gnu95\n"
+     ]
+    }
+   ],
+   "source": [
+    "%fortran_config -vvv --fcompiler gnu95"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9897a7e4",
+   "metadata": {},
+   "source": [
+    "Now the use of `%%fortran` will include `-vvv --fcompiler gnu95` implicitly"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fe47d30c",
+   "metadata": {
+    "tags": [
+     "random",
+     "slow"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "%%fortran\n",
+    "\n",
+    "module hi\n",
+    "  integer :: five = 5\n",
+    "end module   "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5293bf6c",
+   "metadata": {},
+   "source": [
+    "We can see whatever the default config has"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "54480e4b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Current defaults arguments for %fortran:\n",
+      "\t-vvv --fcompiler gnu95\n"
+     ]
+    }
+   ],
+   "source": [
+    "%fortran_config"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "50e9df0e",
+   "metadata": {},
+   "source": [
+    "You can override that global configuration for one specific cell. For example, `%%fortran -vv` will change the the verbose level but still use `--fcompiler gnu95`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1475ba52",
+   "metadata": {
+    "tags": [
+     "random",
+     "slow"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "%%fortran -vv\n",
+    "\n",
+    "module hi\n",
+    "  integer :: five = 5\n",
+    "end module   "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26df09eb",
+   "metadata": {},
+   "source": [
+    "To clear the custom defaults and back to the defaults (no arguments) use:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "3321871f",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Deleted custom config. Back to default arguments for %%fortran\n"
+     ]
+    }
+   ],
+   "source": [
+    "%fortran_config --defaults"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0be16a46-9ebe-40d5-a130-6dbdd81a13e7",
+   "metadata": {
+    "tags": [
+     "random"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "%fortran_config {f_config}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "723266a0",
+   "metadata": {},
+   "source": [
+    "## Help on f2py \n",
+    "\n",
+    "F2py has some flag that output help. See the docstring of `%f2py_help`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "09f050a3",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "tags": [
+     "random"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "%f2py_help --link blas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f8fd3a4a",
+   "metadata": {
+    "tags": [
+     "random",
+     "slow"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "%f2py_help --fcompiler"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d02f8355",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "tags": [
+     "random",
+     "slow"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "%f2py_help --compiler"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f71526a3",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "---------------\n",
+    "# Final\n",
+    "* Bugs? Ideas? [Open an issue](https://github.com/mgaitan/fortran_magic)\n",
+    "* Do you want to collaborate? [Fork it](https://github.com/mgaitan/fortran_magic/fork)! and send a pull-request\n",
+    "## Cell tags\n",
+    "Tags     | Descriptions\n",
+    "---------|--------------\n",
+    "`random` | Tests don't check outpus tagged cells. `Clear Outputs` before commit. \n",
+    "`fast`   | Will be tested on `pytest -m 'fast'`\n",
+    "`slow`   | Don't tested on `pytest -m 'not slow'` (pytest-astropy plugin: `pytest --run-slow`)\n",
+    "\n"
+   ]
   }
- ]
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.10"
+  },
+  "toc-autonumbering": false,
+  "toc-showtags": true
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/documentation.ipynb
+++ b/documentation.ipynb
@@ -126,6 +126,10 @@
     "else:\n",
     "        # For Unix, compilers are usually more compatible.\n",
     "    f_config = \"\"\n",
+    "\n",
+    "    # Disable only deprecated NumPy API warning without disable any APIs.\n",
+    "f_config += \" --extra '-DNPY_NO_DEPRECATED_API=0'\"\n",
+    "\n",
     "%fortran_config {f_config}"
    ]
   },
@@ -229,7 +233,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 6,
    "id": "0b155099-12b3-451d-b8cc-e6f4e6971226",
    "metadata": {
     "tags": [
@@ -269,7 +273,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "0c0d794b",
    "metadata": {
     "tags": []
@@ -285,7 +289,7 @@
     }
    ],
    "source": [
-    "%%fortran -v \n",
+    "%%fortran -v\n",
     "\n",
     "module hi\n",
     "  integer :: five = 5\n",
@@ -307,7 +311,7 @@
    },
    "outputs": [],
    "source": [
-    "%%fortran -vv \n",
+    "%%fortran -vv\n",
     "\n",
     "module hi\n",
     "  integer :: five = 5\n",
@@ -345,7 +349,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "2d4750df",
    "metadata": {
     "collapsed": false,
@@ -380,7 +384,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "88eb2644",
    "metadata": {
     "collapsed": false,
@@ -413,7 +417,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "3e40e3d4-e2c5-4398-97ac-f6eaaa7531b3",
    "metadata": {
     "tags": []
@@ -483,7 +487,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "385be515",
    "metadata": {
     "collapsed": false,
@@ -499,7 +503,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "94ff10f7",
    "metadata": {
     "tags": []
@@ -544,7 +548,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "67c73007",
    "metadata": {
     "collapsed": false,
@@ -560,7 +564,7 @@
        "array([-0.19565217,  0.47826087])"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -572,7 +576,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "1fcd6beb-ffad-4787-90fc-683850018b66",
    "metadata": {
     "tags": []
@@ -597,6 +601,8 @@
     "      %%fortran --extra '-D<define> -U<name>'\n",
     "   \n",
     "      %%fortran --extra '-DPREPEND_FORTRAN -DUPPERCASE_FORTRAN'\n",
+    "      \n",
+    "      %%fortran --extra '-DNPY_NO_DEPRECATED_API=0'\n",
     "      \n",
     "The option `--extra` could be given multiple times."
    ]
@@ -648,7 +654,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "id": "3786a402",
    "metadata": {
     "collapsed": false,
@@ -707,7 +713,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "id": "54480e4b",
    "metadata": {
     "tags": []
@@ -731,22 +737,30 @@
    "id": "50e9df0e",
    "metadata": {},
    "source": [
-    "You can override that global configuration for one specific cell. For example, `%%fortran -vv` will change the the verbose level but still use `--fcompiler gnu95`"
+    "You can override that global configuration for one specific cell. For example, `%%fortran -v` will change the the verbose level but still use `--fcompiler gnu95`"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "id": "1475ba52",
    "metadata": {
     "tags": [
-     "random",
      "slow"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Ok. The following fortran objects are ready to use: hi\n"
+     ]
+    }
+   ],
    "source": [
-    "%%fortran -vv\n",
+    "%%fortran -v\n",
     "\n",
     "module hi\n",
     "  integer :: five = 5\n",
@@ -763,7 +777,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "id": "3321871f",
    "metadata": {
     "collapsed": false,

--- a/fortranmagic.py
+++ b/fortranmagic.py
@@ -18,7 +18,6 @@ import imp
 import io
 import os
 import sys
-#import subprocess
 from subprocess import Popen, PIPE
 
 import errno
@@ -28,7 +27,6 @@ try:
 except ImportError:
     import md5 as hashlib
 
-from IPython.core.error import UsageError
 from IPython.core.magic import Magics, magics_class, line_magic, cell_magic
 from IPython.core import display, magic_arguments
 from IPython.utils import py3compat
@@ -185,12 +183,8 @@ class FortranMagics(Magics):
                 if e.errno == errno.ENOENT:
                     print("Couldn't find program: %r" % command[0])
                     return
-                else:
-                    raise
-            try:
-                out, err = p.communicate(input=None)
-            except:
-                pass
+                raise
+            out, err = p.communicate(input=None)
             if err:
                 sys.stderr.write(err.decode())
                 sys.stderr.flush()
@@ -365,7 +359,7 @@ class FortranMagics(Magics):
         res = self._run_f2py(f2py_args + ['-m', module_name, '-c', f90_file],
                              verbosity=args.verbosity)
         if res != 0:
-           raise RuntimeError("f2py failed, see output")
+            raise RuntimeError("f2py failed, see output")
 
         self._code_cache[key] = module_name
         module = imp.load_dynamic(module_name, module_path)
@@ -389,6 +383,7 @@ class FortranMagics(Magics):
             build_extension.finalize_options()
             self._so_ext = build_extension.get_ext_filename('')
             return self._so_ext
+
 
 __doc__ = __doc__.format(FORTRAN_DOC=' ' * 8 + FortranMagics.fortran.__doc__)
 

--- a/fortranmagic.py
+++ b/fortranmagic.py
@@ -43,7 +43,7 @@ from distutils.command.build_ext import build_ext
 from distutils.version import LooseVersion
 
 
-__version__ = '0.7.1'
+__version__ = '0.7.2'
 fcompiler.load_all_fcompiler_classes()
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+markers =
+	fast:	test only cells with tags 'fast'
+	medium: test untagged cells and with tags 'fast'
+	slow:	don't test cells with tags 'slow'

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ long_description = (open('README.rst').read() + '\n\n' +
 
 setup(
     name='fortran-magic',
-    version='0.7.1',
+    version='0.7.2',
     description='An extension for IPython that help to use Fortran in '
                 'your interactive session.',
     long_description=long_description,
@@ -17,7 +17,7 @@ setup(
     license='BSD',
     keywords="ipython notebook fortran f2py science",
     py_modules=['fortranmagic'],
-    install_requires=['ipython', 'numpy'],
+    install_requires=['ipython', 'numpy', 'charset-normalizer'],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',

--- a/test/environment.yml
+++ b/test/environment.yml
@@ -1,0 +1,21 @@
+---
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  # setup.py of fortranmagic.py
+  - ipython
+  - numpy
+  - charset-normalizer
+  # Tests & Lints
+  - flake8
+  - yamllint
+  - pytest
+  - pytest-cov
+  - nbconvert
+  - nbformat
+  - ipykernel
+  # numpy.f2py compilers depends
+  - c-compiler        # only: win-64
+  - fortran-compiler  # only: osx-64, win-64
+...

--- a/test/fib1.f
+++ b/test/fib1.f
@@ -1,0 +1,18 @@
+C FILE: FIB1.F
+      SUBROUTINE FIB(A,N)
+C
+C     CALCULATE FIRST N FIBONACCI NUMBERS
+C
+      INTEGER N
+      REAL*8 A(N)
+      DO I=1,N
+         IF (I.EQ.1) THEN
+            A(I) = 0.0D0
+         ELSEIF (I.EQ.2) THEN
+            A(I) = 1.0D0
+         ELSE
+            A(I) = A(I-1) + A(I-2)
+         ENDIF
+      ENDDO
+      END
+C END FILE FIB1.F

--- a/test/test_f2py.py
+++ b/test/test_f2py.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+import numpy as np
+import numpy.f2py
+import os
+import platform
+import subprocess
+import sys
+
+
+sys.path.insert(0, os.getcwd())  # Load modules from `pytest` starting directory
+
+if platform.system() == 'Windows':
+    extra_args = ['--fcompiler=gnu95', '--compiler=mingw32']
+else:
+    extra_args = []
+
+
+# Test numpy.f2py.compile
+# See: https://numpy.org/doc/stable/f2py/usage.html#numpy.f2py.compile
+@pytest.mark.skipif(platform.system() == 'Windows',
+                    reason="Probably gnu95/mingw32 can't load module "
+                           "with print")
+@pytest.mark.slow
+def test_f2py_compile_fsource(capfd):
+    mod = 'hello'
+    fsource = '''
+      subroutine foo
+      use iso_fortran_env
+      print*, "Hello world!"
+      flush(unit=output_unit)  ! GNU extension: call flush() / flush(unit=6)
+      end
+    '''
+    assert 0 == numpy.f2py.compile(fsource, modulename=mod, verbose=0,
+                                   extra_args=extra_args)
+
+    import hello
+
+    hello.foo()
+
+    out, err = capfd.readouterr()
+    sout = out.splitlines()
+    assert " Hello world!" in sout  # Fortran `print` add first space
+
+
+# Test numpy.f2py command line
+# https://numpy.org/doc/stable/f2py/f2py.getting-started.html#
+@pytest.mark.slow
+def test_f2py_command():
+    tdir = 'test'
+    mod = 'fib1'
+    ret = subprocess.run([sys.executable, '-m', 'numpy.f2py',
+                          '-c', tdir + '/' + mod + '.f', '-m', mod]
+                         + extra_args,
+                         check=True)
+    assert 0 == ret.returncode
+
+    import fib1
+
+    a = np.zeros(8, 'd')
+    fib1.fib(a)
+    np.testing.assert_allclose(a, [0., 1., 1., 2., 3., 5., 8., 13.])

--- a/test/test_fortranmagic.py
+++ b/test/test_fortranmagic.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+import pytest
+import warnings
+
+import copy
+import nbformat
+from nbconvert.preprocessors import ExecutePreprocessor
+import os
+import subprocess
+import sys
+
+
+sys.path.insert(0, os.getcwd())  # Load modules from `pytest` starting directory
+
+
+def test_setup_version():
+    import fortranmagic
+
+    assert (fortranmagic.__version__ == subprocess.check_output(
+                [sys.executable, "setup.py", "--version"]).decode().rstrip())
+
+
+class SkipExecutePreprocessor(ExecutePreprocessor):
+    def __init__(self, tags=None, **kwargs):
+        self._tags = tags
+        return super().__init__(**kwargs)
+
+    def preprocess_cell(self, cell, resources, index):
+        if 'tags' in cell['metadata']:
+            stags = set(cell['metadata']['tags'])
+        else:
+            stags = {'_medium'}
+        if not (stags & self._tags):
+            return
+        return super().preprocess_cell(cell, resources, index)
+
+
+dte_tags = {'random', 'slow', 'fast'}
+dte_testing = set()
+
+
+def documentation_testing_engine(tags: set):
+    global dte_testing
+    if not (tags - dte_testing):
+        pytest.skip(str(tags) + " previously tested")
+    assert not dte_testing, "Bad test_documentation_*() order"
+    dte_testing |= tags
+
+    with open('documentation.ipynb', 'r') as f:
+        test_documentation = nbformat.read(f, nbformat.NO_CONVERT)
+
+    ep = SkipExecutePreprocessor(tags=tags, timeout=600)
+    exec_documentation = copy.deepcopy(test_documentation)
+    ep.preprocess(exec_documentation)
+
+    assert len(test_documentation.cells) == len(exec_documentation.cells)
+    for i in range(len(test_documentation.cells)):
+        t = test_documentation.cells[i]
+        e = exec_documentation.cells[i]
+        if 'tags' in t['metadata']:
+            stags = set(t['metadata']['tags'])
+            if stags - dte_tags:
+                warnings.warn(Warning(
+                            "Test documentation.ipynb unknown tags: " +
+                            str({'1'})))
+            if 'random' in stags:
+                continue
+        assert not (('outputs' in t) ^ ('outputs' in e))
+        if 'outputs' not in t:
+            continue
+        for to, eo in zip(t['outputs'], e['outputs']):
+            if 'execution_count' in to:
+                cto, ceo = to.copy(), eo.copy()
+                ceo['execution_count'] = cto['execution_count']
+                assert cto == ceo, "for cell[%d]: %s" % (i, t['source'])
+
+
+@pytest.mark.slow
+def test_documentation_slow():
+    documentation_testing_engine({'slow', '_medium', 'fast'})
+
+
+@pytest.mark.medium
+def test_documentation_outputs():
+    documentation_testing_engine({'_medium', 'fast'})
+
+
+@pytest.mark.fast
+def test_documentation_fast():
+    documentation_testing_engine({'fast'})


### PR DESCRIPTION
For `conda-forge` environments on macOS, Ubuntu and Windows: 
- Checking the possibility of executing all cells of `documentation.ipynb` by `nbformat` and `nbconvert`;
- Checking the match of the cells results that do not have the `random` tag;
- Correction of documentation regarding compilers flags, including for Windows;
- Checks YAML and Python files by `yamllint` and `flake8`;
- So far `flake8... --exit-zero...` (python linter) due to open warnings.

#29 