### PR TITLE
Node 24, Python 3.15 ready

### DIFF
--- a/.github/workflows/cleanup_pr.yml
+++ b/.github/workflows/cleanup_pr.yml
@@ -1,0 +1,22 @@
+---
+name: Clean PR
+
+# https://github.com/marketplace/actions/clean-cache
+# https://github.com/OpenGrabeso/clean-cache
+
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+      pull-requests: read
+    steps:
+
+      - name: Clean cache for the branch name
+        uses: opengrabeso/clean-cache@v1.1.0

--- a/.github/workflows/cleanup_push.yml
+++ b/.github/workflows/cleanup_push.yml
@@ -1,0 +1,20 @@
+---
+name: Clean cache by push
+
+# https://github.com/marketplace/actions/clean-cache
+# https://github.com/OpenGrabeso/clean-cache
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches: ['**']
+
+jobs:
+  clean:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: opengrabeso/clean-cache@v1.1.0
+        with:
+          post: true
+          keep: 2

--- a/.github/workflows/micromamba.yml
+++ b/.github/workflows/micromamba.yml
@@ -24,9 +24,9 @@ jobs:
             os_pkgs: "fortran-compiler"
 
           - os: "macos-26-intel"
+            python-version: "3.14"
             platform: "darwin-intel"
             os_pkgs: "fortran-compiler"
-            python-version: "3.14"
 
           - os: "ubuntu-latest"
             platform: "linux"
@@ -35,6 +35,19 @@ jobs:
           - os: "windows-latest"
             platform: "win32"
             os_pkgs: "m2w64-gcc-fortran mkl-devel"
+
+          # For fortran compiler example
+          - os: "ubuntu-latest"
+            python-version: "3.14"
+            platform: "linux"
+            os_pkgs: "flang libflang-rt mkl-devel"
+            explicit_test: true
+
+          - os: "windows-latest"
+            python-version: "3.14"
+            platform: "win32"
+            os_pkgs: "flang flang-rt_win-64 m2w64-gcc-fortran mkl-devel"
+            explicit_test: true
 
     name: ${{ matrix.platform }} py${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
@@ -143,6 +156,13 @@ jobs:
       - name: Test with pytest
         run: |
           PYTHONUTF8=1 JUPYTER_PLATFORM_DIRS=1 uv run --group dev pytest
+          if [ "${{ matrix.explicit_test }}" == "true" ]; then
+            echo "Native: `< native_fortran.txt`"
+            echo "Explicit: `< explicit_fortran.txt`"
+            if cmp native_fortran.txt explicit_fortran.txt; then
+              exit 1
+            fi
+          fi
 
       - name: Beta test on Python beta
         if: env.python_beta_on == matrix.python-version
@@ -151,6 +171,13 @@ jobs:
             PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 \
               PYTHONUTF8=1 JUPYTER_PLATFORM_DIRS=1 uv \
               run --group dev --python=python${{ env.python_beta }} pytest
+            if [ "${{ matrix.explicit_test }}" == "true" ]; then
+              echo "Native: `< native_fortran.txt`"
+              echo "Explicit: `< explicit_fortran.txt`"
+              if cmp native_fortran.txt explicit_fortran.txt; then
+                exit 1
+              fi
+            fi
           else
             echo "Unsuitable gcc for build of NumPy"  # FIXME
             echo "PATH=$PATH"

--- a/.github/workflows/micromamba.yml
+++ b/.github/workflows/micromamba.yml
@@ -3,45 +3,49 @@ name: micromamba/jupyter application
 
 on:  # yamllint disable-line rule:truthy
   push:
-    branches: ['*']
-
+    branches: [master]
   pull_request:
     branches: ['*']
+
+env:
+  python_beta: "3.15"  # Latest pre-release version for beta tests, see logs
+  python_beta_on: "3.14"
 
 jobs:
   build:
     strategy:
       fail-fast: true
       matrix:
-        os: ["macos", "ubuntu", "windows"]
+        os: ["macos-latest", "ubuntu-latest", "windows-latest"]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         include:
-          - os: "macos"
+          - os: "macos-latest"
             platform: "darwin"
             os_pkgs: "fortran-compiler"
 
-          - os: "ubuntu"
-            platform: "linux"
-            os_pkgs: ""
+          - os: "macos-26-intel"
+            platform: "darwin-intel"
+            os_pkgs: "fortran-compiler"
+            python-version: "3.14"
 
-          - os: "windows"
+          - os: "ubuntu-latest"
+            platform: "linux"
+            os_pkgs: "mkl-devel"
+
+          - os: "windows-latest"
             platform: "win32"
-            os_pkgs: "m2w64-gcc-fortran"
+            os_pkgs: "m2w64-gcc-fortran mkl-devel"
 
     name: ${{ matrix.platform }} py${{ matrix.python-version }}
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os }}
     defaults:
       run:
         shell: bash -el {0}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - name: Get current date
-        id: date
-        run: echo "date=$(date +%Y-%m-%d)" >> "${GITHUB_OUTPUT}"
-
-      - uses: mamba-org/setup-micromamba@v1
+      - uses: mamba-org/setup-micromamba@v3
         env:
           CACHE_NUMBER: 0  # modify to reset cache manually
         with:
@@ -51,17 +55,11 @@ jobs:
           environment-file: tests/base-environment.yml
           create-args: >-
             python=${{ matrix.python-version }} ${{ matrix.os_pkgs }}
-          cache-environment: false
-          cache-downloads: false
+          cache-environment: true
+          cache-downloads: true
 
-      - name: Configure pkg-config path
-        run: |
-          if [ "${{ matrix.platform }}" = "win32" ]; then
-            pkgconfig_path="$CONDA_PREFIX/Library/lib/pkgconfig"
-          else
-            pkgconfig_path="$CONDA_PREFIX/lib/pkgconfig"
-          fi
-          echo "PKG_CONFIG_PATH=$pkgconfig_path" >> "$GITHUB_ENV"
+      - name: Setup `uv` with caches by default
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Lint with ruff & yamllint
         run: |
@@ -73,34 +71,27 @@ jobs:
           uv run --group dev ruff check .
           uv run --group dev ruff format --check .
 
-      - name: Workaround conda pkg-config for win32 f2py
-        if: ${{ matrix.platform == 'win32' }}
+      - name: Workaround conda pkg-config BLAS/LAPACK
         run: |
-          pc_dir="$CONDA_PREFIX/Library/lib/pkgconfig"
-          if [ -f "$pc_dir/mkl-sdl.pc" ]; then
-            cp -n "$pc_dir/mkl-sdl.pc" "$pc_dir/lapack.pc"
-            cp -n "$pc_dir/mkl-sdl.pc" "$pc_dir/blas.pc"
-          fi
-
-      - name: f2py workaround  # https://github.com/numpy/numpy/issues/26107
-        run: |
-          npv=`python -m numpy.f2py -v`
-          if [ "$npv" "<" "2" ]; then
-            ff=`python -c "import numpy.f2py; print(numpy.f2py.__file__)"`
-            mbt=`dirname $ff`/_backends/meson.build.template
-            mv "$mbt" "$mbt".orig
-            cp "$mbt".orig "$mbt"
-            sed \
-              -e "/import('python').find_installation(/s/'\${python}', //" \
-              -i -- "$mbt"
-            if diff -w -u "$mbt".orig "$mbt" ; then
-              echo "FAIL: Workaround patch"
-              exit 2
+          if pkg-config --exists mkl-sdl; then
+            mkl_sdl_dir="`pkg-config --variable=pcfiledir mkl-sdl`"
+            mkl_sdl="$mkl_sdl_dir/mkl-sdl.pc"
+            if pkg-config --exists blas; then
+              echo "Have blas in `pkg-config --variable=pcfiledir blas`"
             else
-              echo "OK: Workaround patch"
+              blas="$mkl_sdl_dir/blas.pc"
+              echo "Hack, use: $mkl_sdl as $blas"
+              cp "$mkl_sdl" "$blas"
+            fi
+            if pkg-config --exists lapack; then
+              echo "Have lapack in `pkg-config --variable=pcfiledir lapack`"
+            else
+              lapack="$mkl_sdl_dir/lapack.pc"
+              echo "Hack, use: $mkl_sdl as $lapack"
+              cp "$mkl_sdl" "$lapack"
             fi
           else
-            echo "Workaround don't needed"
+            echo "Don't have mkl-sdl"
           fi
 
       - name: Precheck f2py
@@ -114,10 +105,12 @@ jobs:
           echo "ninja:     " ; ninja --version
           cmake --version
           echo "pkg-config:" ; pkg-config --version
+          type pkg-config
+          echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH"
 
           pkg-config --list-all
 
-          ld_lapack="--dep lapack --dep blas"
+          ld_lapack="--dep lapack"
 
           python -m numpy.f2py --backend meson --verbose -c tests/fib1.f -m fib1
           python -c 'if 1:
@@ -128,9 +121,6 @@ jobs:
             fib1.fib(a)
             print(a)
             '
-
-          python -m numpy.f2py --verbose --help-link blas
-          python -m numpy.f2py --verbose --help-link lapack
 
           if pkg-config --exists blas && pkg-config --exists lapack; then
             python -m numpy.f2py --backend meson --verbose \
@@ -152,5 +142,18 @@ jobs:
 
       - name: Test with pytest
         run: |
-          JUPYTER_PLATFORM_DIRS=1 uv run --group dev pytest
+          PYTHONUTF8=1 JUPYTER_PLATFORM_DIRS=1 uv run --group dev pytest
+
+      - name: Beta test on Python beta
+        if: env.python_beta_on == matrix.python-version
+        run: |
+          if [ "${{ matrix.platform }}" != "win32" ]; then
+            PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 \
+              PYTHONUTF8=1 JUPYTER_PLATFORM_DIRS=1 uv \
+              run --group dev --python=python${{ env.python_beta }} pytest
+          else
+            echo "Unsuitable gcc for build of NumPy"  # FIXME
+            echo "PATH=$PATH"
+            gcc --version || echo No gcc
+          fi
 ...

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+---
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+        args: ["--markdown-linebreak-ext=md"]
+      - id: no-commit-to-branch
+  - repo: local
+    hooks:
+      - id: yamllint
+        name: Start `yamllint`
+        entry: ./.pre-commit-yamllint.sh
+        language: script
+      - id: ruff
+        name: Start `ruff`
+        entry: ./.pre-commit-ruff.sh
+        language: script

--- a/.pre-commit-ruff.sh
+++ b/.pre-commit-ruff.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+set -e
+uv run --group dev ruff check .
+uv run --group dev ruff format --check .

--- a/.pre-commit-yamllint.sh
+++ b/.pre-commit-yamllint.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+
+for f in "$@" ; do
+    case "${f}" in
+     *.yml|*.yaml)
+	 printf "${f}\0"
+	 ;;
+    esac
+done | xargs -0 yamllint

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,11 @@
 # Changelog
 
-## 1.0 / 2025-12-24
+## 1.0 / 2026-05-10
 
 - Switch packaging to `pyproject.toml` with Hatchling and embed pytest config.
 - Drop legacy distutils backend and require Meson for f2py builds.
-- Support Python 3.10 through 3.14.
+- Support Python 3.10 through 3.14 (3.15 ready, CI tests for 3.15.0b1 or
+  above).
 - Convert README and changelog to Markdown.
 - Update release automation to build/publish with `uv`.
 - Stabilize IPython cache handling and test isolation.
@@ -15,8 +16,11 @@
 - Fix README test parser edge case for missing prefixes.
 - Direct dependencies on meson and ninja simplify installation and
   configuration.
-- The ability to open and try the documentation notebook in Google
-  Colab or GitHub Codespace without a local installation.
+- The ability to open and try the documentation notebook in Google Colab or
+  GitHub Codespace without a local installation.
+- Fix documentation for free-threading Python.
+- Fix documentation for `meson` semantics of the `--link` option.
+- Fix CI for Node24.js.
 
 ## 0.9 / 2024-05-27
 

--- a/documentation.ipynb
+++ b/documentation.ipynb
@@ -230,7 +230,7 @@
      "output_type": "stream",
      "text": [
       "New default arguments for %fortran:\n",
-      "\t--extra '-DNPY_NO_DEPRECATED_API=0' --extra '--freethreading-compatible'\n"
+      "\t--extra '-DNPY_NO_DEPRECATED_API=0'\n"
      ]
     }
    ],
@@ -477,7 +477,7 @@
      "output_type": "stream",
      "text": [
       "Running...\n",
-      "   /Users/leo/opt/anaconda3/envs/fm14/bin/python -m numpy.f2py -DNPY_NO_DEPRECATED_API=0 --freethreading-compatible --backend meson -m _fortran_magic_b8fea2044bce52806cd67ec7e4a56970 -c /Users/leo/.cache/ipython/fortranmagic/58ee3608/_fortran_magic_b8fea2044bce52806cd67ec7e4a56970.f90\n",
+      "   /Users/leo/opt/anaconda3/envs/sage312/bin/python -m numpy.f2py -DNPY_NO_DEPRECATED_API=0 --backend meson -m _fortran_magic_7be1c5206e177d1fbb63b0d3005edf57 -c /Users/leo/.cache/ipython/fortranmagic/63ef9d35/_fortran_magic_7be1c5206e177d1fbb63b0d3005edf57.f90\n",
       "\n",
       "Ok. The following fortran objects are ready to use: hi\n"
      ]
@@ -528,57 +528,69 @@
      "output_type": "stream",
      "text": [
       "Running...\n",
-      "   /Users/leo/opt/anaconda3/envs/fm14/bin/python -m numpy.f2py -DNPY_NO_DEPRECATED_API=0 --freethreading-compatible --backend meson -m _fortran_magic_26cdf19b621d862d3c30f9b4d1311eea -c /Users/leo/.cache/ipython/fortranmagic/58ee3608/_fortran_magic_26cdf19b621d862d3c30f9b4d1311eea.f90\n",
+      "   /Users/leo/opt/anaconda3/envs/sage312/bin/python -m numpy.f2py -DNPY_NO_DEPRECATED_API=0 --backend meson -m _fortran_magic_223b367eb8603d786c042a2a7138c916 -c /Users/leo/.cache/ipython/fortranmagic/63ef9d35/_fortran_magic_223b367eb8603d786c042a2a7138c916.f90\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "                                                  \r"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "The Meson build system\n",
-      "Version: 1.11.1\n",
-      "Source dir: /private/var/folders/wy/z0gbkfgs7mv24ryqkdm90rm40009rh/T/tmp79d_fpa8\n",
-      "Build dir: /private/var/folders/wy/z0gbkfgs7mv24ryqkdm90rm40009rh/T/tmp79d_fpa8/bbdir\n",
+      "Version: 1.4.1\n",
+      "Source dir: /private/var/folders/wy/z0gbkfgs7mv24ryqkdm90rm40009rh/T/tmp7ve5vls3\n",
+      "Build dir: /private/var/folders/wy/z0gbkfgs7mv24ryqkdm90rm40009rh/T/tmp7ve5vls3/bbdir\n",
       "Build type: native build\n",
-      "Project name: _fortran_magic_26cdf19b621d862d3c30f9b4d1311eea\n",
+      "Project name: _fortran_magic_223b367eb8603d786c042a2a7138c916\n",
       "Project version: 0.1\n",
-      "Fortran compiler for the host machine: /Users/leo/opt/anaconda3/envs/fm14/bin/x86_64-apple-darwin13.4.0-gfortran (gcc 14.3.0 \"GNU Fortran (GCC) 14.3.0\")\n",
-      "Fortran linker for the host machine: /Users/leo/opt/anaconda3/envs/fm14/bin/x86_64-apple-darwin13.4.0-gfortran ld64 956.6\n",
-      "C compiler for the host machine: x86_64-apple-darwin13.4.0-clang (clang 22.1.4 \"clang version 22.1.4\")\n",
-      "C linker for the host machine: x86_64-apple-darwin13.4.0-clang ld64 956.6\n",
+      "Fortran compiler for the host machine: /Users/leo/opt/anaconda3/envs/sage312/bin/x86_64-apple-darwin13.4.0-gfortran (gcc 12.3.0 \"GNU Fortran (GCC) 12.3.0\")\n",
+      "Fortran linker for the host machine: /Users/leo/opt/anaconda3/envs/sage312/bin/x86_64-apple-darwin13.4.0-gfortran ld64 711\n",
+      "C compiler for the host machine: x86_64-apple-darwin13.4.0-clang (clang 18.1.8 \"clang version 18.1.8\")\n",
+      "C linker for the host machine: x86_64-apple-darwin13.4.0-clang ld64 711\n",
       "Host machine cpu family: x86_64\n",
       "Host machine cpu: x86_64\n",
-      "Program /Users/leo/opt/anaconda3/envs/fm14/bin/python found: YES (/Users/leo/opt/anaconda3/envs/fm14/bin/python)\n",
-      "Found pkg-config: YES (/Users/leo/opt/anaconda3/envs/fm14/bin/pkg-config) 0.29.2\n",
-      "Run-time dependency python found: YES 3.14\n",
+      "Program /Users/leo/opt/anaconda3/envs/sage312/bin/python found: YES (/Users/leo/opt/anaconda3/envs/sage312/bin/python)\n",
+      "Found pkg-config: YES (/Users/leo/opt/anaconda3/envs/sage312/bin/pkg-config) 0.29.2\n",
+      "Run-time dependency python found: YES 3.12\n",
       "Library quadmath found: YES\n",
       "Build targets in project: 1\n",
       "\n",
-      "Found ninja-1.13.0.git.kitware.jobserver-pipe-1 at /Users/leo/opt/anaconda3/envs/fm14/bin/ninja\n",
-      "ninja: Entering directory `/private/var/folders/wy/z0gbkfgs7mv24ryqkdm90rm40009rh/T/tmp79d_fpa8/bbdir'\n",
-      "[1/7] Scanning target _fortran_magic_26cdf19b621d862d3c30f9b4d1311eea.cpython-314t-darwin for modules\n",
-      "[2/7] Compiling C object _fortran_magic_26cdf19b621d862d3c30f9b4d1311eea.cpython-314t-darwin.so.p/_fortran_magic_26cdf19b621d862d3c30f9b4d1311eeamodule.c.o\n",
-      "[3/7] Generating dynamic dependency information for target _fortran_magic_26cdf19b621d862d3c30f9b4d1311eea.cpython-314t-darwin\n",
-      "[4/7] Compiling Fortran object _fortran_magic_26cdf19b621d862d3c30f9b4d1311eea.cpython-314t-darwin.so.p/_fortran_magic_26cdf19b621d862d3c30f9b4d1311eea.f90.o\n",
-      "[5/7] Compiling C object _fortran_magic_26cdf19b621d862d3c30f9b4d1311eea.cpython-314t-darwin.so.p/ae3d3c9e3dd52f82cd6cddf9976623962144650a_.._.._f2py_src_fortranobject.c.o\n",
-      "[6/7] Compiling Fortran object _fortran_magic_26cdf19b621d862d3c30f9b4d1311eea.cpython-314t-darwin.so.p/_fortran_magic_26cdf19b621d862d3c30f9b4d1311eea-f2pywrappers2.f90.o\n",
-      "[7/7] Linking target _fortran_magic_26cdf19b621d862d3c30f9b4d1311eea.cpython-314t-darwin.so\n",
+      "Found ninja-1.12.1 at /Users/leo/opt/anaconda3/envs/sage312/bin/ninja\n",
+      "ninja: Entering directory `/private/var/folders/wy/z0gbkfgs7mv24ryqkdm90rm40009rh/T/tmp7ve5vls3/bbdir'\n",
+      "[1/6] Module scanner.\n",
+      "[2/6] Compiling C object _fortran_magic_223b367eb8603d786c042a2a7138c916.cpython-312-darwin.so.p/_fortran_magic_223b367eb8603d786c042a2a7138c916module.c.o\n",
+      "[3/6] Compiling Fortran object _fortran_magic_223b367eb8603d786c042a2a7138c916.cpython-312-darwin.so.p/_fortran_magic_223b367eb8603d786c042a2a7138c916.f90.o\n",
+      "[4/6] Compiling Fortran object _fortran_magic_223b367eb8603d786c042a2a7138c916.cpython-312-darwin.so.p/_fortran_magic_223b367eb8603d786c042a2a7138c916-f2pywrappers2.f90.o\n",
+      "[5/6] Compiling C object _fortran_magic_223b367eb8603d786c042a2a7138c916.cpython-312-darwin.so.p/fe8ba268408f5e96d7853cd66343a44ca86c9daa_.._.._f2py_src_fortranobject.c.o\n",
+      "[6/6] Linking target _fortran_magic_223b367eb8603d786c042a2a7138c916.cpython-312-darwin.so\n",
       "INFO: autodetecting backend as ninja\n",
-      "INFO: calculating backend command to run: /Users/leo/opt/anaconda3/envs/fm14/bin/ninja -C /private/var/folders/wy/z0gbkfgs7mv24ryqkdm90rm40009rh/T/tmp79d_fpa8/bbdir\n",
+      "INFO: calculating backend command to run: /Users/leo/opt/anaconda3/envs/sage312/bin/ninja -C /private/var/folders/wy/z0gbkfgs7mv24ryqkdm90rm40009rh/T/tmp7ve5vls3/bbdir\n",
       "Using meson backend\n",
       "Will pass --lower to f2py\n",
       "See https://numpy.org/doc/stable/f2py/buildtools/meson.html\n",
       "Reading fortran codes...\n",
-      "\tReading file '/Users/leo/.cache/ipython/fortranmagic/58ee3608/_fortran_magic_26cdf19b621d862d3c30f9b4d1311eea.f90' (format:free)\n",
+      "\tReading file '/Users/leo/.cache/ipython/fortranmagic/63ef9d35/_fortran_magic_223b367eb8603d786c042a2a7138c916.f90' (format:free)\n",
       "Post-processing...\n",
-      "\tBlock: _fortran_magic_26cdf19b621d862d3c30f9b4d1311eea\n",
+      "\tBlock: _fortran_magic_223b367eb8603d786c042a2a7138c916\n",
       "\t\t\tBlock: hi\n",
       "Applying post-processing hooks...\n",
       "  character_backward_compatibility_hook\n",
       "Post-processing (stage 2)...\n",
-      "\tBlock: _fortran_magic_26cdf19b621d862d3c30f9b4d1311eea\n",
+      "\tBlock: _fortran_magic_223b367eb8603d786c042a2a7138c916\n",
       "\t\tBlock: unknown_interface\n",
       "\t\t\tBlock: hi\n",
       "Building modules...\n",
-      "    Building module \"_fortran_magic_26cdf19b621d862d3c30f9b4d1311eea\"...\n",
+      "    Building module \"_fortran_magic_223b367eb8603d786c042a2a7138c916\"...\n",
       "\t\tConstructing F90 module support for \"hi\"...\n",
       "\t\t  Variables: five\n",
-      "    Wrote C/API module \"_fortran_magic_26cdf19b621d862d3c30f9b4d1311eea\" to file \"./_fortran_magic_26cdf19b621d862d3c30f9b4d1311eeamodule.c\"\n",
-      "    Fortran 90 wrappers are saved to \"./_fortran_magic_26cdf19b621d862d3c30f9b4d1311eea-f2pywrappers2.f90\"\n",
+      "    Wrote C/API module \"_fortran_magic_223b367eb8603d786c042a2a7138c916\" to file \"./_fortran_magic_223b367eb8603d786c042a2a7138c916module.c\"\n",
+      "    Fortran 90 wrappers are saved to \"./_fortran_magic_223b367eb8603d786c042a2a7138c916-f2pywrappers2.f90\"\n",
       "\n",
       "Ok. The following fortran objects are ready to use: hi\n"
      ]
@@ -766,7 +778,7 @@
      "output_type": "stream",
      "text": [
       "Running...\n",
-      "   /Users/leo/opt/anaconda3/envs/fm14/bin/python -m numpy.f2py --dep lapack -DNPY_NO_DEPRECATED_API=0 --freethreading-compatible --backend meson -m _fortran_magic_ba634a0dc45970bdf7dfa9e99fd13954 -c /Users/leo/.cache/ipython/fortranmagic/58ee3608/_fortran_magic_ba634a0dc45970bdf7dfa9e99fd13954.f90\n",
+      "   /Users/leo/opt/anaconda3/envs/sage312/bin/python -m numpy.f2py --dep lapack -DNPY_NO_DEPRECATED_API=0 --backend meson -m _fortran_magic_0342abf13d2778b794907cc22b002074 -c /Users/leo/.cache/ipython/fortranmagic/63ef9d35/_fortran_magic_0342abf13d2778b794907cc22b002074.f90\n",
       "\n",
       "Ok. The following fortran objects are ready to use: solve\n"
      ]
@@ -961,6 +973,156 @@
   },
   {
    "cell_type": "markdown",
+   "id": "aacd8f07-ac73-4625-a310-11195755b7d1",
+   "metadata": {},
+   "source": [
+    "## Explicit compiler selection\n",
+    "\n",
+    "The ways to explicitly specify the compiler are described in the `f2py` documentation:\n",
+    "- [Pass a compiler name](https://numpy.org/doc/stable/f2py/buildtools/distutils-to-meson.html#pass-a-compiler-name);\n",
+    "- [F2PY and Windows Intel Fortran](https://numpy.org/doc/stable/f2py/windows/intel.html).\n",
+    "\n",
+    "For `meson`, at a minimum, the environment variable `FC` should be defined, but for some compilers it may be necessary to use additional flags and/or environment variables."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "0f373791-9a85-4358-b5cd-f0f996efa8fd",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found ifort\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import shutil\n",
+    "import sys\n",
+    "\n",
+    "\n",
+    "def restore_fc() -> None:\n",
+    "    if \"_start_restore_fc\" in globals():\n",
+    "        if _start_restore_fc is not None:\n",
+    "            os.environ[\"FC\"] = _start_restore_fc\n",
+    "        else:\n",
+    "            os.environ.pop(\"FC\", None)\n",
+    "\n",
+    "\n",
+    "if \"_start_restore_fc\" not in globals():\n",
+    "    _start_restore_fc = os.environ.get(\"FC\")\n",
+    "restore_fc()\n",
+    "\n",
+    "explicit_fortran_flags = \"\"\n",
+    "for fc in \"ifort\", \"ifx\", \"nvfortran\", \"flang\":\n",
+    "    if shutil.which(fc):\n",
+    "        os.environ[\"FC\"] = fc\n",
+    "        if fc == \"ifort\":\n",
+    "            ifort_path = shutil.which(fc)\n",
+    "            ifort_prefix = os.path.dirname(os.path.dirname(os.path.dirname(ifort_path)))\n",
+    "            explicit_fortran_flags = f\"--extra '-L{ifort_prefix}/compiler/lib'\"\n",
+    "        elif fc == \"nvfortran\":\n",
+    "            nv_path = shutil.which(fc)\n",
+    "            nv_libdir = os.path.dirname(os.path.dirname(nv_path)) + \"/lib\"\n",
+    "            if nv_libdir not in os.environ[\"LD_LIBRARY_PATH\"]:\n",
+    "                print(f\"WARNING: {nv_libdir} not in LD_LIBRARY_PATH\", file=sys.stderr)\n",
+    "            explicit_fortran_flags = f\"--extra '-L{nv_libdir} -lnvf -lnvc'\"\n",
+    "        print(f\"Found {fc}\")\n",
+    "        break\n",
+    "else:\n",
+    "    print(\"Not found ifort, ifx, nvfortran or flang\")\n",
+    "# Need for multiply changes\n",
+    "# %fortran_config --clean-cache"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "21eb216d-6daf-4188-8a8c-5ccd790b261c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%fortran {explicit_fortran_flags}\n",
+    "subroutine explicit_fortran(version)\n",
+    "    use iso_fortran_env\n",
+    "\n",
+    "    character(len=256), intent(out):: version\n",
+    "    version = compiler_version()\n",
+    "end subroutine"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "48004fcf-4add-4d81-ab23-e72387e0ad8a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Intel(R) Fortran Intel(R) 64 Compiler Classic for applications running on Intel(R) 64, Version 2021.1.2 Build 20201208_000000\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(explicit_fortran().decode())\n",
+    "with open(\"explicit_fortran.txt\", \"wb\") as f:\n",
+    "    f.write(explicit_fortran())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "76e25741-1861-4e00-9686-19305d95f4ab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "restore_fc()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "6ec00178-b34a-4c6d-9ba0-884ce8cf717d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%fortran\n",
+    "subroutine native_fortran(version)\n",
+    "    use iso_fortran_env\n",
+    "\n",
+    "    character(len=256), intent(out):: version\n",
+    "    version = compiler_version()\n",
+    "end subroutine"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "0abdccfd-c16a-4815-a485-0076f58d6eae",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "GCC version 12.3.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(native_fortran().decode())\n",
+    "with open(\"native_fortran.txt\", \"wb\") as f:\n",
+    "    f.write(native_fortran())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "82842bda",
    "metadata": {
     "editable": true,
@@ -992,7 +1154,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 28,
    "id": "3786a402",
    "metadata": {
     "editable": true,
@@ -1009,7 +1171,7 @@
      "output_type": "stream",
      "text": [
       "New default arguments for %fortran:\n",
-      "\t-vvv --extra '-DNPY_NO_DEPRECATED_API=0' --extra '--freethreading-compatible'\n"
+      "\t-vvv --extra '-DNPY_NO_DEPRECATED_API=0'\n"
      ]
     }
    ],
@@ -1033,7 +1195,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 29,
    "id": "fe47d30c",
    "metadata": {
     "editable": true,
@@ -1052,57 +1214,69 @@
      "output_type": "stream",
      "text": [
       "Running...\n",
-      "   /Users/leo/opt/anaconda3/envs/fm14/bin/python -m numpy.f2py -DNPY_NO_DEPRECATED_API=0 --freethreading-compatible --backend meson -m _fortran_magic_7bb62d7c77dda18c98a33fe3fdeef44b -c /Users/leo/.cache/ipython/fortranmagic/58ee3608/_fortran_magic_7bb62d7c77dda18c98a33fe3fdeef44b.f90\n",
+      "   /Users/leo/opt/anaconda3/envs/sage312/bin/python -m numpy.f2py -DNPY_NO_DEPRECATED_API=0 --backend meson -m _fortran_magic_a476f0ed9e1d12dbb7d04961ec285525 -c /Users/leo/.cache/ipython/fortranmagic/63ef9d35/_fortran_magic_a476f0ed9e1d12dbb7d04961ec285525.f90\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "                                                  \r"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "The Meson build system\n",
-      "Version: 1.11.1\n",
-      "Source dir: /private/var/folders/wy/z0gbkfgs7mv24ryqkdm90rm40009rh/T/tmpimjlxu4r\n",
-      "Build dir: /private/var/folders/wy/z0gbkfgs7mv24ryqkdm90rm40009rh/T/tmpimjlxu4r/bbdir\n",
+      "Version: 1.4.1\n",
+      "Source dir: /private/var/folders/wy/z0gbkfgs7mv24ryqkdm90rm40009rh/T/tmptckhvjon\n",
+      "Build dir: /private/var/folders/wy/z0gbkfgs7mv24ryqkdm90rm40009rh/T/tmptckhvjon/bbdir\n",
       "Build type: native build\n",
-      "Project name: _fortran_magic_7bb62d7c77dda18c98a33fe3fdeef44b\n",
+      "Project name: _fortran_magic_a476f0ed9e1d12dbb7d04961ec285525\n",
       "Project version: 0.1\n",
-      "Fortran compiler for the host machine: /Users/leo/opt/anaconda3/envs/fm14/bin/x86_64-apple-darwin13.4.0-gfortran (gcc 14.3.0 \"GNU Fortran (GCC) 14.3.0\")\n",
-      "Fortran linker for the host machine: /Users/leo/opt/anaconda3/envs/fm14/bin/x86_64-apple-darwin13.4.0-gfortran ld64 956.6\n",
-      "C compiler for the host machine: x86_64-apple-darwin13.4.0-clang (clang 22.1.4 \"clang version 22.1.4\")\n",
-      "C linker for the host machine: x86_64-apple-darwin13.4.0-clang ld64 956.6\n",
+      "Fortran compiler for the host machine: /Users/leo/opt/anaconda3/envs/sage312/bin/x86_64-apple-darwin13.4.0-gfortran (gcc 12.3.0 \"GNU Fortran (GCC) 12.3.0\")\n",
+      "Fortran linker for the host machine: /Users/leo/opt/anaconda3/envs/sage312/bin/x86_64-apple-darwin13.4.0-gfortran ld64 711\n",
+      "C compiler for the host machine: x86_64-apple-darwin13.4.0-clang (clang 18.1.8 \"clang version 18.1.8\")\n",
+      "C linker for the host machine: x86_64-apple-darwin13.4.0-clang ld64 711\n",
       "Host machine cpu family: x86_64\n",
       "Host machine cpu: x86_64\n",
-      "Program /Users/leo/opt/anaconda3/envs/fm14/bin/python found: YES (/Users/leo/opt/anaconda3/envs/fm14/bin/python)\n",
-      "Found pkg-config: YES (/Users/leo/opt/anaconda3/envs/fm14/bin/pkg-config) 0.29.2\n",
-      "Run-time dependency python found: YES 3.14\n",
+      "Program /Users/leo/opt/anaconda3/envs/sage312/bin/python found: YES (/Users/leo/opt/anaconda3/envs/sage312/bin/python)\n",
+      "Found pkg-config: YES (/Users/leo/opt/anaconda3/envs/sage312/bin/pkg-config) 0.29.2\n",
+      "Run-time dependency python found: YES 3.12\n",
       "Library quadmath found: YES\n",
       "Build targets in project: 1\n",
       "\n",
-      "Found ninja-1.13.0.git.kitware.jobserver-pipe-1 at /Users/leo/opt/anaconda3/envs/fm14/bin/ninja\n",
-      "ninja: Entering directory `/private/var/folders/wy/z0gbkfgs7mv24ryqkdm90rm40009rh/T/tmpimjlxu4r/bbdir'\n",
-      "[1/7] Scanning target _fortran_magic_7bb62d7c77dda18c98a33fe3fdeef44b.cpython-314t-darwin for modules\n",
-      "[2/7] Compiling C object _fortran_magic_7bb62d7c77dda18c98a33fe3fdeef44b.cpython-314t-darwin.so.p/_fortran_magic_7bb62d7c77dda18c98a33fe3fdeef44bmodule.c.o\n",
-      "[3/7] Generating dynamic dependency information for target _fortran_magic_7bb62d7c77dda18c98a33fe3fdeef44b.cpython-314t-darwin\n",
-      "[4/7] Compiling Fortran object _fortran_magic_7bb62d7c77dda18c98a33fe3fdeef44b.cpython-314t-darwin.so.p/_fortran_magic_7bb62d7c77dda18c98a33fe3fdeef44b.f90.o\n",
-      "[5/7] Compiling C object _fortran_magic_7bb62d7c77dda18c98a33fe3fdeef44b.cpython-314t-darwin.so.p/ae3d3c9e3dd52f82cd6cddf9976623962144650a_.._.._f2py_src_fortranobject.c.o\n",
-      "[6/7] Compiling Fortran object _fortran_magic_7bb62d7c77dda18c98a33fe3fdeef44b.cpython-314t-darwin.so.p/_fortran_magic_7bb62d7c77dda18c98a33fe3fdeef44b-f2pywrappers2.f90.o\n",
-      "[7/7] Linking target _fortran_magic_7bb62d7c77dda18c98a33fe3fdeef44b.cpython-314t-darwin.so\n",
+      "Found ninja-1.12.1 at /Users/leo/opt/anaconda3/envs/sage312/bin/ninja\n",
+      "ninja: Entering directory `/private/var/folders/wy/z0gbkfgs7mv24ryqkdm90rm40009rh/T/tmptckhvjon/bbdir'\n",
+      "[1/6] Module scanner.\n",
+      "[2/6] Compiling C object _fortran_magic_a476f0ed9e1d12dbb7d04961ec285525.cpython-312-darwin.so.p/_fortran_magic_a476f0ed9e1d12dbb7d04961ec285525module.c.o\n",
+      "[3/6] Compiling Fortran object _fortran_magic_a476f0ed9e1d12dbb7d04961ec285525.cpython-312-darwin.so.p/_fortran_magic_a476f0ed9e1d12dbb7d04961ec285525.f90.o\n",
+      "[4/6] Compiling Fortran object _fortran_magic_a476f0ed9e1d12dbb7d04961ec285525.cpython-312-darwin.so.p/_fortran_magic_a476f0ed9e1d12dbb7d04961ec285525-f2pywrappers2.f90.o\n",
+      "[5/6] Compiling C object _fortran_magic_a476f0ed9e1d12dbb7d04961ec285525.cpython-312-darwin.so.p/fe8ba268408f5e96d7853cd66343a44ca86c9daa_.._.._f2py_src_fortranobject.c.o\n",
+      "[6/6] Linking target _fortran_magic_a476f0ed9e1d12dbb7d04961ec285525.cpython-312-darwin.so\n",
       "INFO: autodetecting backend as ninja\n",
-      "INFO: calculating backend command to run: /Users/leo/opt/anaconda3/envs/fm14/bin/ninja -C /private/var/folders/wy/z0gbkfgs7mv24ryqkdm90rm40009rh/T/tmpimjlxu4r/bbdir\n",
+      "INFO: calculating backend command to run: /Users/leo/opt/anaconda3/envs/sage312/bin/ninja -C /private/var/folders/wy/z0gbkfgs7mv24ryqkdm90rm40009rh/T/tmptckhvjon/bbdir\n",
       "Using meson backend\n",
       "Will pass --lower to f2py\n",
       "See https://numpy.org/doc/stable/f2py/buildtools/meson.html\n",
       "Reading fortran codes...\n",
-      "\tReading file '/Users/leo/.cache/ipython/fortranmagic/58ee3608/_fortran_magic_7bb62d7c77dda18c98a33fe3fdeef44b.f90' (format:free)\n",
+      "\tReading file '/Users/leo/.cache/ipython/fortranmagic/63ef9d35/_fortran_magic_a476f0ed9e1d12dbb7d04961ec285525.f90' (format:free)\n",
       "Post-processing...\n",
-      "\tBlock: _fortran_magic_7bb62d7c77dda18c98a33fe3fdeef44b\n",
+      "\tBlock: _fortran_magic_a476f0ed9e1d12dbb7d04961ec285525\n",
       "\t\t\tBlock: hi\n",
       "Applying post-processing hooks...\n",
       "  character_backward_compatibility_hook\n",
       "Post-processing (stage 2)...\n",
-      "\tBlock: _fortran_magic_7bb62d7c77dda18c98a33fe3fdeef44b\n",
+      "\tBlock: _fortran_magic_a476f0ed9e1d12dbb7d04961ec285525\n",
       "\t\tBlock: unknown_interface\n",
       "\t\t\tBlock: hi\n",
       "Building modules...\n",
-      "    Building module \"_fortran_magic_7bb62d7c77dda18c98a33fe3fdeef44b\"...\n",
+      "    Building module \"_fortran_magic_a476f0ed9e1d12dbb7d04961ec285525\"...\n",
       "\t\tConstructing F90 module support for \"hi\"...\n",
       "\t\t  Variables: five\n",
-      "    Wrote C/API module \"_fortran_magic_7bb62d7c77dda18c98a33fe3fdeef44b\" to file \"./_fortran_magic_7bb62d7c77dda18c98a33fe3fdeef44bmodule.c\"\n",
-      "    Fortran 90 wrappers are saved to \"./_fortran_magic_7bb62d7c77dda18c98a33fe3fdeef44b-f2pywrappers2.f90\"\n",
+      "    Wrote C/API module \"_fortran_magic_a476f0ed9e1d12dbb7d04961ec285525\" to file \"./_fortran_magic_a476f0ed9e1d12dbb7d04961ec285525module.c\"\n",
+      "    Fortran 90 wrappers are saved to \"./_fortran_magic_a476f0ed9e1d12dbb7d04961ec285525-f2pywrappers2.f90\"\n",
       "\n",
       "Ok. The following fortran objects are ready to use: hi\n"
      ]
@@ -1132,7 +1306,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 30,
    "id": "54480e4b",
    "metadata": {
     "editable": true,
@@ -1147,7 +1321,7 @@
      "output_type": "stream",
      "text": [
       "Current defaults arguments for %fortran:\n",
-      "\t-vvv --extra '-DNPY_NO_DEPRECATED_API=0' --extra '--freethreading-compatible'\n"
+      "\t-vvv --extra '-DNPY_NO_DEPRECATED_API=0'\n"
      ]
     }
    ],
@@ -1171,7 +1345,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 31,
    "id": "1475ba52",
    "metadata": {
     "editable": true,
@@ -1216,7 +1390,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 32,
    "id": "3321871f",
    "metadata": {
     "collapsed": false,
@@ -1244,7 +1418,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 33,
    "id": "0be16a46-9ebe-40d5-a130-6dbdd81a13e7",
    "metadata": {
     "editable": true,
@@ -1261,7 +1435,7 @@
      "output_type": "stream",
      "text": [
       "New default arguments for %fortran:\n",
-      "\t--extra '-DNPY_NO_DEPRECATED_API=0' --extra '--freethreading-compatible'\n"
+      "\t--extra '-DNPY_NO_DEPRECATED_API=0'\n"
      ]
     }
    ],
@@ -1297,7 +1471,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 34,
    "id": "09f050a3",
    "metadata": {
     "collapsed": false,
@@ -1328,7 +1502,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 35,
    "id": "f8fd3a4a",
    "metadata": {
     "editable": true,
@@ -1357,7 +1531,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 36,
    "id": "d02f8355",
    "metadata": {
     "editable": true,
@@ -1402,7 +1576,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 37,
    "id": "acf599f8-245b-4b8e-b582-1e9f6f1f52db",
    "metadata": {
     "editable": true,
@@ -1418,7 +1592,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 38,
    "id": "beae6740-c9db-40d0-aeae-802d4883403b",
    "metadata": {
     "editable": true,
@@ -1435,7 +1609,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The extension _fortran_magic_c29d6cd6e4abbdc523657e7f27c3d56d is already loaded. To reload it, use:\n",
+      "The extension _fortran_magic_bc05cae19ce858e85996b32c580a2f97 is already loaded. To reload it, use:\n",
       "  %fortran_config --clean-cache\n"
      ]
     }
@@ -1454,7 +1628,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 39,
    "id": "0d7a144d-c857-40c3-99e8-5ecd95ac8f82",
    "metadata": {
     "editable": true,
@@ -1489,7 +1663,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 40,
    "id": "fa8575a6-01ef-48b1-a243-9ad353965123",
    "metadata": {
     "editable": true,
@@ -1515,7 +1689,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 41,
    "id": "2a6e2289-8875-48b6-a8cf-e831e1b777a5",
    "metadata": {
     "editable": true,
@@ -1548,7 +1722,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 42,
    "id": "96b0a47c-dadc-48d3-beda-49c0511622f5",
    "metadata": {
     "editable": true,
@@ -1564,8 +1738,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Clean cache: /Users/leo/.cache/ipython/fortranmagic/58ee3608\n",
-      "New cache: /Users/leo/.cache/ipython/fortranmagic/e29edef9\n"
+      "Clean cache: /Users/leo/.cache/ipython/fortranmagic/63ef9d35\n",
+      "New cache: /Users/leo/.cache/ipython/fortranmagic/746d5849\n"
      ]
     }
    ],
@@ -1590,7 +1764,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 43,
    "id": "8f61fddc-676d-499d-b9f5-2ac9d1b6b744",
    "metadata": {
     "editable": true,
@@ -1618,7 +1792,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 44,
    "id": "7fb27b941602401d91542211134fc71a",
    "metadata": {
     "editable": true,
@@ -1636,7 +1810,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 45,
    "id": "7e0eafe3-c8c7-4fd7-ae23-617ad791a9cb",
    "metadata": {
     "editable": true,
@@ -1657,7 +1831,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 46,
    "id": "f3cb72e1-55a3-4242-baa0-02b2053aea94",
    "metadata": {
     "editable": true,
@@ -1692,7 +1866,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 47,
    "id": "ba5cae37-4358-488e-8d8c-187a8bfea2bc",
    "metadata": {},
    "outputs": [],
@@ -1722,17 +1896,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 48,
    "id": "298c9df1-ad28-4736-8003-17c26d9e55a6",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(16, array([ 0, 15,  2, 12, 14,  8, 13,  4, 10,  6], dtype=int32))"
+       "(16, array([15,  0, 12,  3,  2,  8,  4, 11, 13,  1], dtype=int32))"
       ]
      },
-     "execution_count": 42,
+     "execution_count": 48,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1759,7 +1933,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 49,
    "id": "6f246f15-e5ea-4566-b8e2-c644b928c64d",
    "metadata": {},
    "outputs": [],
@@ -1795,17 +1969,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 50,
    "id": "4ceb70e8-3214-4ad0-85bd-ee4fa3e8b443",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([7, 6, 5, 4, 3, 2, 1, 3, 2, 1], dtype=int32)"
+       "array([1, 1, 1, 1, 1, 1, 1, 1, 1, 1], dtype=int32)"
       ]
      },
-     "execution_count": 44,
+     "execution_count": 50,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1816,6 +1990,34 @@
     "pt_sample.run_thr[:] = 0\n",
     "pt_sample.max_thr[:] = 0\n",
     "pt_thrs = [threading.Thread(target=pt_sample.pt_native, args=(i + 1,)) for i in range(pt_sample.max_threads)]\n",
+    "for pt in pt_thrs:\n",
+    "    pt.start()\n",
+    "for pt in pt_thrs:\n",
+    "    pt.join()\n",
+    "pt_sample.max_thr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "id": "8ea35b0f-6701-4b75-a527-3d1aef36ec81",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([ 8,  9, 10,  6,  5,  4,  7,  3,  1,  2], dtype=int32)"
+      ]
+     },
+     "execution_count": 51,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pt_sample.run_thr[:] = 0\n",
+    "pt_sample.max_thr[:] = 0\n",
+    "pt_thrs = [threading.Thread(target=pt_sample.pt_threadsafe, args=(i + 1,)) for i in range(pt_sample.max_threads)]\n",
     "for pt in pt_thrs:\n",
     "    pt.start()\n",
     "for pt in pt_thrs:\n",
@@ -1900,7 +2102,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.14.4"
+   "version": "3.12.0"
   },
   "toc-autonumbering": false,
   "toc-showtags": true

--- a/documentation.ipynb
+++ b/documentation.ipynb
@@ -230,7 +230,7 @@
      "output_type": "stream",
      "text": [
       "New default arguments for %fortran:\n",
-      "\t--extra '-DNPY_NO_DEPRECATED_API=0'\n"
+      "\t--extra '-DNPY_NO_DEPRECATED_API=0' --extra '--freethreading-compatible'\n"
      ]
     }
    ],
@@ -238,6 +238,9 @@
     "import numpy as np\n",
     "\n",
     "f_config = \"--extra '-DNPY_NO_DEPRECATED_API=0'\"\n",
+    "\n",
+    "if np.version.version >= \"2.1\":\n",
+    "    f_config += \" --extra '--freethreading-compatible'\"\n",
     "\n",
     "%fortran_config {f_config}"
    ]
@@ -474,7 +477,7 @@
      "output_type": "stream",
      "text": [
       "Running...\n",
-      "   /Users/leo/opt/anaconda3/envs/sage312/bin/python -m numpy.f2py -DNPY_NO_DEPRECATED_API=0 --backend meson -m _fortran_magic_47bbfc7f119bc93e4ed46ac1cbeff2b3 -c /Users/leo/.cache/ipython/fortranmagic/26beaced/_fortran_magic_47bbfc7f119bc93e4ed46ac1cbeff2b3.f90\n",
+      "   /Users/leo/opt/anaconda3/envs/fm14/bin/python -m numpy.f2py -DNPY_NO_DEPRECATED_API=0 --freethreading-compatible --backend meson -m _fortran_magic_b8fea2044bce52806cd67ec7e4a56970 -c /Users/leo/.cache/ipython/fortranmagic/58ee3608/_fortran_magic_b8fea2044bce52806cd67ec7e4a56970.f90\n",
       "\n",
       "Ok. The following fortran objects are ready to use: hi\n"
      ]
@@ -506,7 +509,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "228e92af",
    "metadata": {
     "editable": true,
@@ -519,7 +522,68 @@
      "random_long"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Running...\n",
+      "   /Users/leo/opt/anaconda3/envs/fm14/bin/python -m numpy.f2py -DNPY_NO_DEPRECATED_API=0 --freethreading-compatible --backend meson -m _fortran_magic_26cdf19b621d862d3c30f9b4d1311eea -c /Users/leo/.cache/ipython/fortranmagic/58ee3608/_fortran_magic_26cdf19b621d862d3c30f9b4d1311eea.f90\n",
+      "The Meson build system\n",
+      "Version: 1.11.1\n",
+      "Source dir: /private/var/folders/wy/z0gbkfgs7mv24ryqkdm90rm40009rh/T/tmp79d_fpa8\n",
+      "Build dir: /private/var/folders/wy/z0gbkfgs7mv24ryqkdm90rm40009rh/T/tmp79d_fpa8/bbdir\n",
+      "Build type: native build\n",
+      "Project name: _fortran_magic_26cdf19b621d862d3c30f9b4d1311eea\n",
+      "Project version: 0.1\n",
+      "Fortran compiler for the host machine: /Users/leo/opt/anaconda3/envs/fm14/bin/x86_64-apple-darwin13.4.0-gfortran (gcc 14.3.0 \"GNU Fortran (GCC) 14.3.0\")\n",
+      "Fortran linker for the host machine: /Users/leo/opt/anaconda3/envs/fm14/bin/x86_64-apple-darwin13.4.0-gfortran ld64 956.6\n",
+      "C compiler for the host machine: x86_64-apple-darwin13.4.0-clang (clang 22.1.4 \"clang version 22.1.4\")\n",
+      "C linker for the host machine: x86_64-apple-darwin13.4.0-clang ld64 956.6\n",
+      "Host machine cpu family: x86_64\n",
+      "Host machine cpu: x86_64\n",
+      "Program /Users/leo/opt/anaconda3/envs/fm14/bin/python found: YES (/Users/leo/opt/anaconda3/envs/fm14/bin/python)\n",
+      "Found pkg-config: YES (/Users/leo/opt/anaconda3/envs/fm14/bin/pkg-config) 0.29.2\n",
+      "Run-time dependency python found: YES 3.14\n",
+      "Library quadmath found: YES\n",
+      "Build targets in project: 1\n",
+      "\n",
+      "Found ninja-1.13.0.git.kitware.jobserver-pipe-1 at /Users/leo/opt/anaconda3/envs/fm14/bin/ninja\n",
+      "ninja: Entering directory `/private/var/folders/wy/z0gbkfgs7mv24ryqkdm90rm40009rh/T/tmp79d_fpa8/bbdir'\n",
+      "[1/7] Scanning target _fortran_magic_26cdf19b621d862d3c30f9b4d1311eea.cpython-314t-darwin for modules\n",
+      "[2/7] Compiling C object _fortran_magic_26cdf19b621d862d3c30f9b4d1311eea.cpython-314t-darwin.so.p/_fortran_magic_26cdf19b621d862d3c30f9b4d1311eeamodule.c.o\n",
+      "[3/7] Generating dynamic dependency information for target _fortran_magic_26cdf19b621d862d3c30f9b4d1311eea.cpython-314t-darwin\n",
+      "[4/7] Compiling Fortran object _fortran_magic_26cdf19b621d862d3c30f9b4d1311eea.cpython-314t-darwin.so.p/_fortran_magic_26cdf19b621d862d3c30f9b4d1311eea.f90.o\n",
+      "[5/7] Compiling C object _fortran_magic_26cdf19b621d862d3c30f9b4d1311eea.cpython-314t-darwin.so.p/ae3d3c9e3dd52f82cd6cddf9976623962144650a_.._.._f2py_src_fortranobject.c.o\n",
+      "[6/7] Compiling Fortran object _fortran_magic_26cdf19b621d862d3c30f9b4d1311eea.cpython-314t-darwin.so.p/_fortran_magic_26cdf19b621d862d3c30f9b4d1311eea-f2pywrappers2.f90.o\n",
+      "[7/7] Linking target _fortran_magic_26cdf19b621d862d3c30f9b4d1311eea.cpython-314t-darwin.so\n",
+      "INFO: autodetecting backend as ninja\n",
+      "INFO: calculating backend command to run: /Users/leo/opt/anaconda3/envs/fm14/bin/ninja -C /private/var/folders/wy/z0gbkfgs7mv24ryqkdm90rm40009rh/T/tmp79d_fpa8/bbdir\n",
+      "Using meson backend\n",
+      "Will pass --lower to f2py\n",
+      "See https://numpy.org/doc/stable/f2py/buildtools/meson.html\n",
+      "Reading fortran codes...\n",
+      "\tReading file '/Users/leo/.cache/ipython/fortranmagic/58ee3608/_fortran_magic_26cdf19b621d862d3c30f9b4d1311eea.f90' (format:free)\n",
+      "Post-processing...\n",
+      "\tBlock: _fortran_magic_26cdf19b621d862d3c30f9b4d1311eea\n",
+      "\t\t\tBlock: hi\n",
+      "Applying post-processing hooks...\n",
+      "  character_backward_compatibility_hook\n",
+      "Post-processing (stage 2)...\n",
+      "\tBlock: _fortran_magic_26cdf19b621d862d3c30f9b4d1311eea\n",
+      "\t\tBlock: unknown_interface\n",
+      "\t\t\tBlock: hi\n",
+      "Building modules...\n",
+      "    Building module \"_fortran_magic_26cdf19b621d862d3c30f9b4d1311eea\"...\n",
+      "\t\tConstructing F90 module support for \"hi\"...\n",
+      "\t\t  Variables: five\n",
+      "    Wrote C/API module \"_fortran_magic_26cdf19b621d862d3c30f9b4d1311eea\" to file \"./_fortran_magic_26cdf19b621d862d3c30f9b4d1311eeamodule.c\"\n",
+      "    Fortran 90 wrappers are saved to \"./_fortran_magic_26cdf19b621d862d3c30f9b4d1311eea-f2pywrappers2.f90\"\n",
+      "\n",
+      "Ok. The following fortran objects are ready to use: hi\n"
+     ]
+    }
+   ],
    "source": [
     "%%fortran -vvv\n",
     "\n",
@@ -679,7 +743,8 @@
    "source": [
     "## Linking resources\n",
     "\n",
-    "Use `--link` option. This is `--link-<resource>` in f2py command line"
+    "Use `--link` option. This is `--dep <dependency>` in f2py command line\n",
+    "(`--link-<resource>` for `distutils` backend)"
    ]
   },
   {
@@ -701,7 +766,7 @@
      "output_type": "stream",
      "text": [
       "Running...\n",
-      "   /Users/leo/opt/anaconda3/envs/sage312/bin/python -m numpy.f2py --dep lapack -DNPY_NO_DEPRECATED_API=0 --backend meson -m _fortran_magic_4abccef68ae429c7d4210594302cc7da -c /Users/leo/.cache/ipython/fortranmagic/26beaced/_fortran_magic_4abccef68ae429c7d4210594302cc7da.f90\n",
+      "   /Users/leo/opt/anaconda3/envs/fm14/bin/python -m numpy.f2py --dep lapack -DNPY_NO_DEPRECATED_API=0 --freethreading-compatible --backend meson -m _fortran_magic_ba634a0dc45970bdf7dfa9e99fd13954 -c /Users/leo/.cache/ipython/fortranmagic/58ee3608/_fortran_magic_ba634a0dc45970bdf7dfa9e99fd13954.f90\n",
       "\n",
       "Ok. The following fortran objects are ready to use: solve\n"
      ]
@@ -944,7 +1009,7 @@
      "output_type": "stream",
      "text": [
       "New default arguments for %fortran:\n",
-      "\t-vvv --extra '-DNPY_NO_DEPRECATED_API=0'\n"
+      "\t-vvv --extra '-DNPY_NO_DEPRECATED_API=0' --extra '--freethreading-compatible'\n"
      ]
     }
    ],
@@ -968,7 +1033,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "id": "fe47d30c",
    "metadata": {
     "editable": true,
@@ -981,7 +1046,68 @@
      "random_long"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Running...\n",
+      "   /Users/leo/opt/anaconda3/envs/fm14/bin/python -m numpy.f2py -DNPY_NO_DEPRECATED_API=0 --freethreading-compatible --backend meson -m _fortran_magic_7bb62d7c77dda18c98a33fe3fdeef44b -c /Users/leo/.cache/ipython/fortranmagic/58ee3608/_fortran_magic_7bb62d7c77dda18c98a33fe3fdeef44b.f90\n",
+      "The Meson build system\n",
+      "Version: 1.11.1\n",
+      "Source dir: /private/var/folders/wy/z0gbkfgs7mv24ryqkdm90rm40009rh/T/tmpimjlxu4r\n",
+      "Build dir: /private/var/folders/wy/z0gbkfgs7mv24ryqkdm90rm40009rh/T/tmpimjlxu4r/bbdir\n",
+      "Build type: native build\n",
+      "Project name: _fortran_magic_7bb62d7c77dda18c98a33fe3fdeef44b\n",
+      "Project version: 0.1\n",
+      "Fortran compiler for the host machine: /Users/leo/opt/anaconda3/envs/fm14/bin/x86_64-apple-darwin13.4.0-gfortran (gcc 14.3.0 \"GNU Fortran (GCC) 14.3.0\")\n",
+      "Fortran linker for the host machine: /Users/leo/opt/anaconda3/envs/fm14/bin/x86_64-apple-darwin13.4.0-gfortran ld64 956.6\n",
+      "C compiler for the host machine: x86_64-apple-darwin13.4.0-clang (clang 22.1.4 \"clang version 22.1.4\")\n",
+      "C linker for the host machine: x86_64-apple-darwin13.4.0-clang ld64 956.6\n",
+      "Host machine cpu family: x86_64\n",
+      "Host machine cpu: x86_64\n",
+      "Program /Users/leo/opt/anaconda3/envs/fm14/bin/python found: YES (/Users/leo/opt/anaconda3/envs/fm14/bin/python)\n",
+      "Found pkg-config: YES (/Users/leo/opt/anaconda3/envs/fm14/bin/pkg-config) 0.29.2\n",
+      "Run-time dependency python found: YES 3.14\n",
+      "Library quadmath found: YES\n",
+      "Build targets in project: 1\n",
+      "\n",
+      "Found ninja-1.13.0.git.kitware.jobserver-pipe-1 at /Users/leo/opt/anaconda3/envs/fm14/bin/ninja\n",
+      "ninja: Entering directory `/private/var/folders/wy/z0gbkfgs7mv24ryqkdm90rm40009rh/T/tmpimjlxu4r/bbdir'\n",
+      "[1/7] Scanning target _fortran_magic_7bb62d7c77dda18c98a33fe3fdeef44b.cpython-314t-darwin for modules\n",
+      "[2/7] Compiling C object _fortran_magic_7bb62d7c77dda18c98a33fe3fdeef44b.cpython-314t-darwin.so.p/_fortran_magic_7bb62d7c77dda18c98a33fe3fdeef44bmodule.c.o\n",
+      "[3/7] Generating dynamic dependency information for target _fortran_magic_7bb62d7c77dda18c98a33fe3fdeef44b.cpython-314t-darwin\n",
+      "[4/7] Compiling Fortran object _fortran_magic_7bb62d7c77dda18c98a33fe3fdeef44b.cpython-314t-darwin.so.p/_fortran_magic_7bb62d7c77dda18c98a33fe3fdeef44b.f90.o\n",
+      "[5/7] Compiling C object _fortran_magic_7bb62d7c77dda18c98a33fe3fdeef44b.cpython-314t-darwin.so.p/ae3d3c9e3dd52f82cd6cddf9976623962144650a_.._.._f2py_src_fortranobject.c.o\n",
+      "[6/7] Compiling Fortran object _fortran_magic_7bb62d7c77dda18c98a33fe3fdeef44b.cpython-314t-darwin.so.p/_fortran_magic_7bb62d7c77dda18c98a33fe3fdeef44b-f2pywrappers2.f90.o\n",
+      "[7/7] Linking target _fortran_magic_7bb62d7c77dda18c98a33fe3fdeef44b.cpython-314t-darwin.so\n",
+      "INFO: autodetecting backend as ninja\n",
+      "INFO: calculating backend command to run: /Users/leo/opt/anaconda3/envs/fm14/bin/ninja -C /private/var/folders/wy/z0gbkfgs7mv24ryqkdm90rm40009rh/T/tmpimjlxu4r/bbdir\n",
+      "Using meson backend\n",
+      "Will pass --lower to f2py\n",
+      "See https://numpy.org/doc/stable/f2py/buildtools/meson.html\n",
+      "Reading fortran codes...\n",
+      "\tReading file '/Users/leo/.cache/ipython/fortranmagic/58ee3608/_fortran_magic_7bb62d7c77dda18c98a33fe3fdeef44b.f90' (format:free)\n",
+      "Post-processing...\n",
+      "\tBlock: _fortran_magic_7bb62d7c77dda18c98a33fe3fdeef44b\n",
+      "\t\t\tBlock: hi\n",
+      "Applying post-processing hooks...\n",
+      "  character_backward_compatibility_hook\n",
+      "Post-processing (stage 2)...\n",
+      "\tBlock: _fortran_magic_7bb62d7c77dda18c98a33fe3fdeef44b\n",
+      "\t\tBlock: unknown_interface\n",
+      "\t\t\tBlock: hi\n",
+      "Building modules...\n",
+      "    Building module \"_fortran_magic_7bb62d7c77dda18c98a33fe3fdeef44b\"...\n",
+      "\t\tConstructing F90 module support for \"hi\"...\n",
+      "\t\t  Variables: five\n",
+      "    Wrote C/API module \"_fortran_magic_7bb62d7c77dda18c98a33fe3fdeef44b\" to file \"./_fortran_magic_7bb62d7c77dda18c98a33fe3fdeef44bmodule.c\"\n",
+      "    Fortran 90 wrappers are saved to \"./_fortran_magic_7bb62d7c77dda18c98a33fe3fdeef44b-f2pywrappers2.f90\"\n",
+      "\n",
+      "Ok. The following fortran objects are ready to use: hi\n"
+     ]
+    }
+   ],
    "source": [
     "%%fortran\n",
     "\n",
@@ -1021,7 +1147,7 @@
      "output_type": "stream",
      "text": [
       "Current defaults arguments for %fortran:\n",
-      "\t-vvv --extra '-DNPY_NO_DEPRECATED_API=0'\n"
+      "\t-vvv --extra '-DNPY_NO_DEPRECATED_API=0' --extra '--freethreading-compatible'\n"
      ]
     }
    ],
@@ -1135,7 +1261,7 @@
      "output_type": "stream",
      "text": [
       "New default arguments for %fortran:\n",
-      "\t--extra '-DNPY_NO_DEPRECATED_API=0'\n"
+      "\t--extra '-DNPY_NO_DEPRECATED_API=0' --extra '--freethreading-compatible'\n"
      ]
     }
    ],
@@ -1154,14 +1280,24 @@
     "tags": []
    },
    "source": [
-    "## Help on f2py \n",
+    "## Help on `--link` dependicies option\n",
     "\n",
-    "F2py has some flag that output help. See the docstring of `%f2py_help`"
+    "Currently, for versions of NumPy 2.0.0 and higher and/or\n",
+    "Python 3.12 and higher, the meson build system is used, which\n",
+    "searches for and resolves dependencies in several ways:\n",
+    "`pkg-config`, `CMake find_package`, etc. To select\n",
+    "the `--link` arguments, read the documentation for these packages.\n",
+    "Frequently used dependencies: `blas`, `lapack`, `mkl-sdl`\n",
+    "(MKL, which contains variants of BLAS and LAPACK), `OpenMP`,\n",
+    "`scalapack`.\n",
+    "\n",
+    "Previously, for NumPy versions prior to 1.26.4, `f2py` has some\n",
+    "flag that output help. See the docstring of `%f2py_help`"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "id": "09f050a3",
    "metadata": {
     "collapsed": false,
@@ -1177,14 +1313,22 @@
      "random_long"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Use --dep for meson builds\n"
+     ]
+    }
+   ],
    "source": [
     "%f2py_help --link blas"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "id": "f8fd3a4a",
    "metadata": {
     "editable": true,
@@ -1198,7 +1342,15 @@
      "random_long"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Use --dep for meson builds\n"
+     ]
+    }
+   ],
    "source": [
     "%f2py_help --resources"
    ]
@@ -1283,7 +1435,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The extension _fortran_magic_9d72701d516b1704fe4ad110d877459f is already loaded. To reload it, use:\n",
+      "The extension _fortran_magic_c29d6cd6e4abbdc523657e7f27c3d56d is already loaded. To reload it, use:\n",
       "  %fortran_config --clean-cache\n"
      ]
     }
@@ -1412,8 +1564,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Clean cache: /Users/leo/.cache/ipython/fortranmagic/26beaced\n",
-      "New cache: /Users/leo/.cache/ipython/fortranmagic/64dea1f0\n"
+      "Clean cache: /Users/leo/.cache/ipython/fortranmagic/58ee3608\n",
+      "New cache: /Users/leo/.cache/ipython/fortranmagic/e29edef9\n"
      ]
     }
    ],
@@ -1521,6 +1673,189 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7195b30d-6f80-48b5-8ec3-89aa9d3454dc",
+   "metadata": {},
+   "source": [
+    "# Multithreading"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "61f4a67a-c673-4e4a-a8c4-c8ec6f72def4",
+   "metadata": {},
+   "source": [
+    "## Use OpenMP\n",
+    "\n",
+    "You can use OpenMP, however, in this case you should not\n",
+    "use call-back functions from work threads."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "id": "ba5cae37-4358-488e-8d8c-187a8bfea2bc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%fortran --f90flags='-fopenmp' --link openmp\n",
+    "integer function omp_sample(tids)\n",
+    "    use omp_lib\n",
+    "\n",
+    "    integer, intent(out) :: tids(10)\n",
+    "\n",
+    "    integer nid, cid\n",
+    "\n",
+    "    tids(:) = -1\n",
+    "    nid = 0\n",
+    "    !$omp parallel private(cid)\n",
+    "        !$omp critical\n",
+    "            nid = nid + 1\n",
+    "            cid = nid\n",
+    "        !$omp end critical\n",
+    "        if (cid <= size(tids)) then\n",
+    "            tids(cid) = omp_get_thread_num()\n",
+    "        endif\n",
+    "    !$omp end parallel\n",
+    "    omp_sample = nid\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "id": "298c9df1-ad28-4736-8003-17c26d9e55a6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(16, array([ 0, 15,  2, 12, 14,  8, 13,  4, 10,  6], dtype=int32))"
+      ]
+     },
+     "execution_count": 42,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "omp_sample()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8dd00663-4207-4474-85a8-9d6c08e7d418",
+   "metadata": {},
+   "source": [
+    "## Use Python threading\n",
+    "\n",
+    "When using Python threading, by default, `f2py` holds\n",
+    "GIL until it returns from the fortran function. However, this\n",
+    "behavior can be changed by the directive `!f2py threadsafe`.\n",
+    "\n",
+    "Unfortunately, the use of scalar coarrays or coindexed objects\n",
+    "is undocumented, so thread synchronization or control cache\n",
+    "coherence is somewhat difficult."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "id": "6f246f15-e5ea-4566-b8e2-c644b928c64d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%fortran\n",
+    "module pt_sample\n",
+    "    use iso_fortran_env\n",
+    "\n",
+    "    integer, parameter :: max_threads = 10\n",
+    "    integer run_thr(max_threads)\n",
+    "    integer max_thr(max_threads)\n",
+    "\n",
+    "    private impl_common\n",
+    "contains\n",
+    "    subroutine impl_common(id)\n",
+    "        integer id\n",
+    "        run_thr(id) = 1\n",
+    "        call sleep(1)\n",
+    "        max_thr(id) = sum(run_thr(:))\n",
+    "        run_thr(id) = 0\n",
+    "    end subroutine\n",
+    "    subroutine pt_native(id)\n",
+    "        integer id\n",
+    "        call impl_common(id)\n",
+    "    end subroutine\n",
+    "    subroutine pt_threadsafe(id)\n",
+    "        !f2py threadsafe\n",
+    "        integer id\n",
+    "        call impl_common(id)\n",
+    "    end subroutine\n",
+    "end module"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "id": "4ceb70e8-3214-4ad0-85bd-ee4fa3e8b443",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([7, 6, 5, 4, 3, 2, 1, 3, 2, 1], dtype=int32)"
+      ]
+     },
+     "execution_count": 44,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import threading\n",
+    "\n",
+    "pt_sample.run_thr[:] = 0\n",
+    "pt_sample.max_thr[:] = 0\n",
+    "pt_thrs = [threading.Thread(target=pt_sample.pt_native, args=(i + 1,)) for i in range(pt_sample.max_threads)]\n",
+    "for pt in pt_thrs:\n",
+    "    pt.start()\n",
+    "for pt in pt_thrs:\n",
+    "    pt.join()\n",
+    "pt_sample.max_thr"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "366e1275-a064-40c9-b914-7935f45779d8",
+   "metadata": {},
+   "source": [
+    "## Free-threaded Python\n",
+    "\n",
+    "As a result of the migration process from GIL to Free-threaded\n",
+    "Python, warnings containing the following content may appear when\n",
+    "loading modules (cells)::\n",
+    "```\n",
+    "<frozen importlib._bootstrap>:491: RuntimeWarning: The global\n",
+    "interpreter lock (GIL) has been enabled to load module 'fib1',\n",
+    "which has not declared that it can run safely without the GIL.\n",
+    "To override this behavior and keep the GIL disabled (at your\n",
+    "own risk), run with PYTHON_GIL=0 or -Xgil=0.\n",
+    "```\n",
+    "\n",
+    "If the code in the thread cell is safe, it can be removed with\n",
+    "the option (`NumPY` 2.1 or higher):\n",
+    "```\n",
+    "%%fortran --extra '--freethreading-compatible'\n",
+    "```\n",
+    "\n",
+    "If the code in the entire notebook is thread-safe, then you can\n",
+    "use (`NumPY` 2.1 or higher):\n",
+    "```\n",
+    "%fortran_config --extra '--freethreading-compatible'\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "871526a3",
    "metadata": {
     "editable": true,
@@ -1565,7 +1900,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.0"
+   "version": "3.14.4"
   },
   "toc-autonumbering": false,
   "toc-showtags": true

--- a/fortranmagic.py
+++ b/fortranmagic.py
@@ -27,7 +27,7 @@ from IPython.paths import get_ipython_cache_dir
 from IPython.utils.io import capture_output
 from numpy.f2py import f2py2e
 
-__version__ = "1.0.0a2"
+__version__ = "1.0"
 _VERBOSITY_DEBUG = 2
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "fortran-magic"
 dynamic = ["version"]
 description = "An extension for IPython that help to use Fortran in your interactive session."
 readme = "README.md"
-requires-python = ">=3.10,<3.15"
+requires-python = ">=3.10,<3.16"
 license = { file = "LICENSE" }
 authors = [
   { name = "Martin Gaitan", email = "gaitan@gmail.com" },

--- a/tests/base-environment.yml
+++ b/tests/base-environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - yamllint
   - pytest
   - pytest-cov
-  - uv
+  # - uv                  # use external install for caching
   - meson
   - ninja
   - cmake

--- a/tests/test_f2py.py
+++ b/tests/test_f2py.py
@@ -50,6 +50,10 @@ def test_f2py_command(numpy_correct_compilers) -> None:
     https://numpy.org/doc/stable/f2py/f2py.getting-started.html#
     """
 
+    # FIXME: may be add "--freethreading-compatible" to
+    # `numpy_correct_compilers`, but `numpy_correct_compilers` seems broken
+    freethreading_compatible = ["--freethreading-compatible"] if np.__version__ >= "2.1" else []
+
     tdir = "tests"
     mod = "fib1"
     ret = subprocess.check_call(
@@ -63,6 +67,7 @@ def test_f2py_command(numpy_correct_compilers) -> None:
             tdir + "/" + mod + ".f",
             "-m",
             mod,
+            *freethreading_compatible,
             *numpy_correct_compilers,
         ]
     )

--- a/tests/test_fortran_config.py
+++ b/tests/test_fortran_config.py
@@ -12,6 +12,7 @@ import warnings
 
 import IPython.core.interactiveshell as ici
 import IPython.paths
+import numpy as np
 import pytest
 
 pytestmark = pytest.mark.requires_fortran
@@ -74,6 +75,11 @@ class Cish:
         """Call `%fortran_config` and check success."""
 
         if flgs is not None:
+            # FIXME: may be add "--freethreading-compatible" to
+            # `numpy_correct_compilers`, but `numpy_correct_compilers` seems
+            # broken
+            if np.__version__ >= "2.1":
+                flgs = "--extra '--freethreading-compatible'" + " " + flgs
             if self.numpy_correct_compilers:
                 flgs = self.numpy_correct_compilers + " " + flgs
             elif not flgs:

--- a/tests/test_readme_md.py
+++ b/tests/test_readme_md.py
@@ -51,5 +51,7 @@ def test_ipython_cells() -> None:
         if "Out" in c:
             np.testing.assert_allclose(float("\n".join(cells[-1]["Out"])), float(er.result))
             checked += 1
+        if c["In"][0].startswith("%load_ext") and np.__version__ >= "2.1":
+            ish.run_cell("%fortran_config --extra '--freethreading-compatible'", store_history=False)
 
     assert success > 0 and checked > 0


### PR DESCRIPTION
* Python 3.15 ready (CI tests for 3.15.0b1 or above).
* Docs: the issue of migration to free-threading Python is described (use the `--freethreading-compatible` option,  #55). 
* Docs: `meson` semantics of the `--link` option is described.
* CI: bump version of `checkout@v6` and `setup-micromamba@v3` (upgrade to Node 24).
* CI: cache `micromamba` and `uv`.
* CI: add configuration files for optional pre-commit checks.
* Tests: don't skip `test_documentation_ipynb.py` for `ubuntu-latest` and `windows-latest`.
* Tests: repair irrelevant warnings about GIL.