### PR TITLE
chore: prepare stable 1.0 release

### DIFF
--- a/.github/workflows/micromamba.yml
+++ b/.github/workflows/micromamba.yml
@@ -3,45 +3,66 @@ name: micromamba/jupyter application
 
 on:  # yamllint disable-line rule:truthy
   push:
-    branches: ['*']
-
+    branches: [master]
   pull_request:
     branches: ['*']
+
+permissions:
+  contents: read
+
+env:
+  UV_MALWARE_CHECK: "1"
+  python_beta: "3.15"  # Latest pre-release version for beta tests, see logs
+  python_beta_on: "3.14"
 
 jobs:
   build:
     strategy:
       fail-fast: true
       matrix:
-        os: ["macos", "ubuntu", "windows"]
+        os: ["macos-latest", "ubuntu-latest", "windows-latest"]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         include:
-          - os: "macos"
+          - os: "macos-latest"
             platform: "darwin"
             os_pkgs: "fortran-compiler"
 
-          - os: "ubuntu"
-            platform: "linux"
-            os_pkgs: ""
+          - os: "macos-26-intel"
+            python-version: "3.14"
+            platform: "darwin-intel"
+            os_pkgs: "fortran-compiler"
 
-          - os: "windows"
+          - os: "ubuntu-latest"
+            platform: "linux"
+            os_pkgs: "mkl-devel"
+
+          - os: "windows-latest"
             platform: "win32"
-            os_pkgs: "m2w64-gcc-fortran"
+            os_pkgs: "m2w64-gcc-fortran mkl-devel"
+
+          # For fortran compiler example
+          - os: "ubuntu-latest"
+            python-version: "3.14"
+            platform: "linux"
+            os_pkgs: "flang libflang-rt mkl-devel"
+            explicit_test: true
+
+          - os: "windows-latest"
+            python-version: "3.14"
+            platform: "win32"
+            os_pkgs: "flang flang-rt_win-64 m2w64-gcc-fortran mkl-devel"
+            explicit_test: true
 
     name: ${{ matrix.platform }} py${{ matrix.python-version }}
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os }}
     defaults:
       run:
         shell: bash -el {0}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - name: Get current date
-        id: date
-        run: echo "date=$(date +%Y-%m-%d)" >> "${GITHUB_OUTPUT}"
-
-      - uses: mamba-org/setup-micromamba@v1
+      - uses: mamba-org/setup-micromamba@v3
         env:
           CACHE_NUMBER: 0  # modify to reset cache manually
         with:
@@ -51,17 +72,11 @@ jobs:
           environment-file: tests/base-environment.yml
           create-args: >-
             python=${{ matrix.python-version }} ${{ matrix.os_pkgs }}
-          cache-environment: false
-          cache-downloads: false
+          cache-environment: true
+          cache-downloads: true
 
-      - name: Configure pkg-config path
-        run: |
-          if [ "${{ matrix.platform }}" = "win32" ]; then
-            pkgconfig_path="$CONDA_PREFIX/Library/lib/pkgconfig"
-          else
-            pkgconfig_path="$CONDA_PREFIX/lib/pkgconfig"
-          fi
-          echo "PKG_CONFIG_PATH=$pkgconfig_path" >> "$GITHUB_ENV"
+      - name: Setup `uv` with caches by default
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Lint with ruff & yamllint
         run: |
@@ -73,34 +88,27 @@ jobs:
           uv run --group dev ruff check .
           uv run --group dev ruff format --check .
 
-      - name: Workaround conda pkg-config for win32 f2py
-        if: ${{ matrix.platform == 'win32' }}
+      - name: Workaround conda pkg-config BLAS/LAPACK
         run: |
-          pc_dir="$CONDA_PREFIX/Library/lib/pkgconfig"
-          if [ -f "$pc_dir/mkl-sdl.pc" ]; then
-            cp -n "$pc_dir/mkl-sdl.pc" "$pc_dir/lapack.pc"
-            cp -n "$pc_dir/mkl-sdl.pc" "$pc_dir/blas.pc"
-          fi
-
-      - name: f2py workaround  # https://github.com/numpy/numpy/issues/26107
-        run: |
-          npv=`python -m numpy.f2py -v`
-          if [ "$npv" "<" "2" ]; then
-            ff=`python -c "import numpy.f2py; print(numpy.f2py.__file__)"`
-            mbt=`dirname $ff`/_backends/meson.build.template
-            mv "$mbt" "$mbt".orig
-            cp "$mbt".orig "$mbt"
-            sed \
-              -e "/import('python').find_installation(/s/'\${python}', //" \
-              -i -- "$mbt"
-            if diff -w -u "$mbt".orig "$mbt" ; then
-              echo "FAIL: Workaround patch"
-              exit 2
+          if pkg-config --exists mkl-sdl; then
+            mkl_sdl_dir="`pkg-config --variable=pcfiledir mkl-sdl`"
+            mkl_sdl="$mkl_sdl_dir/mkl-sdl.pc"
+            if pkg-config --exists blas; then
+              echo "Have blas in `pkg-config --variable=pcfiledir blas`"
             else
-              echo "OK: Workaround patch"
+              blas="$mkl_sdl_dir/blas.pc"
+              echo "Hack, use: $mkl_sdl as $blas"
+              cp "$mkl_sdl" "$blas"
+            fi
+            if pkg-config --exists lapack; then
+              echo "Have lapack in `pkg-config --variable=pcfiledir lapack`"
+            else
+              lapack="$mkl_sdl_dir/lapack.pc"
+              echo "Hack, use: $mkl_sdl as $lapack"
+              cp "$mkl_sdl" "$lapack"
             fi
           else
-            echo "Workaround don't needed"
+            echo "Don't have mkl-sdl"
           fi
 
       - name: Precheck f2py
@@ -114,10 +122,12 @@ jobs:
           echo "ninja:     " ; ninja --version
           cmake --version
           echo "pkg-config:" ; pkg-config --version
+          type pkg-config
+          echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH"
 
           pkg-config --list-all
 
-          ld_lapack="--dep lapack --dep blas"
+          ld_lapack="--dep lapack"
 
           python -m numpy.f2py --backend meson --verbose -c tests/fib1.f -m fib1
           python -c 'if 1:
@@ -128,9 +138,6 @@ jobs:
             fib1.fib(a)
             print(a)
             '
-
-          python -m numpy.f2py --verbose --help-link blas
-          python -m numpy.f2py --verbose --help-link lapack
 
           if pkg-config --exists blas && pkg-config --exists lapack; then
             python -m numpy.f2py --backend meson --verbose \
@@ -152,5 +159,32 @@ jobs:
 
       - name: Test with pytest
         run: |
-          JUPYTER_PLATFORM_DIRS=1 uv run --group dev pytest
+          PYTHONUTF8=1 JUPYTER_PLATFORM_DIRS=1 uv run --group dev pytest
+          if [ "${{ matrix.explicit_test }}" == "true" ]; then
+            echo "Native: `< native_fortran.txt`"
+            echo "Explicit: `< explicit_fortran.txt`"
+            if cmp native_fortran.txt explicit_fortran.txt; then
+              exit 1
+            fi
+          fi
+
+      - name: Beta test on Python beta
+        if: env.python_beta_on == matrix.python-version
+        run: |
+          if [ "${{ matrix.platform }}" != "win32" ]; then
+            PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 \
+              PYTHONUTF8=1 JUPYTER_PLATFORM_DIRS=1 uv \
+              run --group dev --python=python${{ env.python_beta }} pytest
+            if [ "${{ matrix.explicit_test }}" == "true" ]; then
+              echo "Native: `< native_fortran.txt`"
+              echo "Explicit: `< explicit_fortran.txt`"
+              if cmp native_fortran.txt explicit_fortran.txt; then
+                exit 1
+              fi
+            fi
+          else
+            echo "Unsuitable gcc for build of NumPy"  # FIXME
+            echo "PATH=$PATH"
+            gcc --version || echo No gcc
+          fi
 ...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@
 # vim:set sw=2 ts=8 et fileencoding=utf8:
 # SPDX-License-Identifier: BSD-3-Clause
 #
-name: Publish Python 🐍 distributions 📦 to PyPI
+name: Publish to PyPI
 
 on:  # yamllint disable-line rule:truthy
   release:
@@ -13,11 +13,12 @@ jobs:
     name: upload release to PyPI
     runs-on: ubuntu-latest
     permissions:
-      # IMPORTANT: this permission is mandatory for trusted publishing
+      contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v7
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8.2.0
       - run: uv build
-      - if: github.event_name == 'release'
-        run: uv publish
+      - name: Generate publish attestations
+        uses: astral-sh/attest-action@f589a42a7efb6fe400b4f400de60b4bc90390027 # v0.0.6
+      - run: uv publish

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,11 @@
 # Changelog
 
-## 1.0 / 2025-12-24
+## 1.0 / 2026-05-10
 
 - Switch packaging to `pyproject.toml` with Hatchling and embed pytest config.
 - Drop legacy distutils backend and require Meson for f2py builds.
-- Support Python 3.10 through 3.14.
+- Support Python 3.10 through 3.14 (3.15 ready, CI tests for 3.15.0b1 or
+  above).
 - Convert README and changelog to Markdown.
 - Update release automation to build/publish with `uv`.
 - Stabilize IPython cache handling and test isolation.
@@ -15,8 +16,11 @@
 - Fix README test parser edge case for missing prefixes.
 - Direct dependencies on meson and ninja simplify installation and
   configuration.
-- The ability to open and try the documentation notebook in Google
-  Colab or GitHub Codespace without a local installation.
+- The ability to open and try the documentation notebook in Google Colab or
+  GitHub Codespace without a local installation.
+- Fix documentation for free-threading Python.
+- Fix documentation for `meson` semantics of the `--link` option.
+- Fix CI for Node24.js.
 
 ## 0.9 / 2024-05-27
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY: install test qa build
+
+export UV_MALWARE_CHECK := 1
+
+install:
+	uv sync
+	prek install
+
+test:
+	JUPYTER_PLATFORM_DIRS=1 uv run --group dev pytest
+
+qa:
+	prek run --all-files
+
+build:
+	uv build

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ compiled. The resulting module is imported and all of its symbols are injected i
 the user's namespace.
 
 - Homepage: https://github.com/mgaitan/fortran_magic
-- Documentation: see [this notebook](http://nbviewer.ipython.org/urls/raw.github.com/mgaitan/fortran_magic/master/documentation.ipynb)
+- Documentation: see [this notebook](https://nbviewer.org/github/mgaitan/fortran_magic/blob/master/documentation.ipynb)
 
 ## Install
 

--- a/documentation.ipynb
+++ b/documentation.ipynb
@@ -96,7 +96,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "d50d4527-974f-44f3-8d12-55806378e40e",
    "metadata": {
     "editable": true,
@@ -105,25 +105,7 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "application/javascript": [
-       "\n",
-       "        if(typeof IPython === 'undefined') {\n",
-       "            console.log('fortranmagic.py: TDOO: JupyterLab ' +\n",
-       "                        'syntax highlight - unimplemented.');\n",
-       "        } else {\n",
-       "            IPython.CodeCell.options_default\n",
-       "            .highlight_modes['magic_fortran'] = {'reg':[/^%%fortran/]};\n",
-       "        }\n",
-       "        "
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "try:\n",
     "    %load_ext fortranmagic\n",
@@ -132,14 +114,12 @@
     "    if \"codespace\" in str(get_ipython().config):\n",
     "        # For GitHub Codespace install GNU Fortran, LAPACK, BLAS and pkg-config\n",
     "        !conda install -y -q -c conda-forge fortran-compiler lapack blas pkgconfig\n",
-    "        %pip install -q -U fortran-magic --pre\n",
-    "        # TODO: remove pre-release version by release\n",
+    "        %pip install -q -U fortran-magic\n",
     "        print(\"Warning: you may need to restart and execute all again\")\n",
     "        %load_ext fortranmagic\n",
     "    elif \"google.colab\" in str(get_ipython().config):\n",
     "        # Google Colab have preinstalled GNU Fortran, LAPACK, BLAS and pkg-config\n",
-    "        %pip install -q -U fortran-magic --pre\n",
-    "        # TODO: remove pre-release version by release\n",
+    "        %pip install -q -U fortran-magic\n",
     "        %load_ext fortranmagic\n",
     "    else:\n",
     "        raise AssertionError(\"Autoinstall\") from err"
@@ -163,7 +143,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "cb7ec369",
    "metadata": {
     "collapsed": false,
@@ -178,16 +158,7 @@
      "fast"
     ]
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The fortranmagic extension is already loaded. To reload it, use:\n",
-      "  %reload_ext fortranmagic\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%load_ext fortranmagic"
    ]
@@ -212,7 +183,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "b204c9a5-229e-4f54-a86b-3540869ef44c",
    "metadata": {
     "editable": true,
@@ -224,20 +195,14 @@
      "random"
     ]
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "New default arguments for %fortran:\n",
-      "\t--extra '-DNPY_NO_DEPRECATED_API=0'\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import numpy as np\n",
     "\n",
     "f_config = \"--extra '-DNPY_NO_DEPRECATED_API=0'\"\n",
+    "\n",
+    "if np.lib.NumpyVersion(np.__version__) >= \"2.1.0\":\n",
+    "    f_config += \" --extra '--freethreading-compatible'\"\n",
     "\n",
     "%fortran_config {f_config}"
    ]
@@ -260,7 +225,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "edddd3c0",
    "metadata": {
     "editable": true,
@@ -286,7 +251,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "05f82b33",
    "metadata": {
     "collapsed": false,
@@ -301,18 +266,7 @@
      "fast"
     ]
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "9.26574e-05"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%precision %g\n",
     "f1(1.0, 2.1415)"
@@ -320,7 +274,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "fea5599d",
    "metadata": {
     "editable": true,
@@ -331,34 +285,14 @@
      "fast"
     ]
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "z = f1(x,y)\n",
-      "\n",
-      "Wrapper for ``f1``.\n",
-      "\n",
-      "Parameters\n",
-      "----------\n",
-      "x : input float\n",
-      "y : input float\n",
-      "\n",
-      "Returns\n",
-      "-------\n",
-      "z : float\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(f1.__doc__)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "0b155099-12b3-451d-b8cc-e6f4e6971226",
    "metadata": {
     "editable": true,
@@ -369,23 +303,7 @@
      "fast"
     ]
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "subroutine f1(x, y, z)\n",
-      "    real, intent(in) :: x,y\n",
-      "    real, intent(out) :: z\n",
-      "\n",
-      "    z = sin(x+y)\n",
-      "\n",
-      "end subroutine f1\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(f1.__source__)"
    ]
@@ -408,7 +326,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "0c0d794b",
    "metadata": {
     "editable": true,
@@ -417,16 +335,7 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Ok. The following fortran objects are ready to use: hi\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%fortran -v\n",
     "\n",
@@ -437,7 +346,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "95150cfc-492b-4bd7-9f00-27995e58e3ed",
    "metadata": {
     "editable": true,
@@ -453,7 +362,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "1c75b752",
    "metadata": {
     "collapsed": false,
@@ -468,18 +377,7 @@
      "random"
     ]
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running...\n",
-      "   /Users/leo/opt/anaconda3/envs/sage312/bin/python -m numpy.f2py -DNPY_NO_DEPRECATED_API=0 --backend meson -m _fortran_magic_47bbfc7f119bc93e4ed46ac1cbeff2b3 -c /Users/leo/.cache/ipython/fortranmagic/26beaced/_fortran_magic_47bbfc7f119bc93e4ed46ac1cbeff2b3.f90\n",
-      "\n",
-      "Ok. The following fortran objects are ready to use: hi\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%fortran -vv\n",
     "\n",
@@ -490,7 +388,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "dcbf20c1-f550-431b-991b-7e715d8a5f5f",
    "metadata": {
     "editable": true,
@@ -530,7 +428,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "6210c503-f27f-4eec-a33e-4f8bdadb14a8",
    "metadata": {
     "editable": true,
@@ -562,7 +460,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "2d4750df",
    "metadata": {
     "collapsed": false,
@@ -575,16 +473,7 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Ok. The following fortran objects are ready to use: zadd\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%fortran -v --f77flags=\"-ffixed-form\"\n",
     "C\n",
@@ -602,7 +491,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "88eb2644",
    "metadata": {
     "collapsed": false,
@@ -615,32 +504,14 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "zadd(a,b,c,n)\n",
-      "\n",
-      "Wrapper for ``zadd``.\n",
-      "\n",
-      "Parameters\n",
-      "----------\n",
-      "a : input rank-1 array('D') with bounds (*)\n",
-      "b : input rank-1 array('D') with bounds (*)\n",
-      "c : input rank-1 array('D') with bounds (*)\n",
-      "n : input int\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(zadd.__doc__)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "3e40e3d4-e2c5-4398-97ac-f6eaaa7531b3",
    "metadata": {
     "editable": true,
@@ -649,15 +520,7 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[0.+0.j 1.+1.j 2.+2.j 3.+3.j 4.+4.j 5.+5.j 6.+6.j 7.+7.j 8.+8.j 9.+9.j]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "a = np.arange(10, dtype=np.cdouble)\n",
     "b = a * complex(0, 1)\n",
@@ -679,12 +542,13 @@
    "source": [
     "## Linking resources\n",
     "\n",
-    "Use `--link` option. This is `--link-<resource>` in f2py command line"
+    "Use `--link` option. This is `--dep <dependency>` in f2py command line\n",
+    "(`--link-<resource>` for `distutils` backend)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "bd257b84",
    "metadata": {
     "editable": true,
@@ -695,18 +559,7 @@
      "random"
     ]
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running...\n",
-      "   /Users/leo/opt/anaconda3/envs/sage312/bin/python -m numpy.f2py --dep lapack -DNPY_NO_DEPRECATED_API=0 --backend meson -m _fortran_magic_4abccef68ae429c7d4210594302cc7da -c /Users/leo/.cache/ipython/fortranmagic/26beaced/_fortran_magic_4abccef68ae429c7d4210594302cc7da.f90\n",
-      "\n",
-      "Ok. The following fortran objects are ready to use: solve\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%fortran --link lapack -vv\n",
     "\n",
@@ -731,7 +584,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "id": "385be515",
    "metadata": {
     "editable": true,
@@ -748,7 +601,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "id": "94ff10f7",
    "metadata": {
     "editable": true,
@@ -757,32 +610,7 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "x = solve(a,b,[n])\n",
-      "\n",
-      "Wrapper for ``solve``.\n",
-      "\n",
-      "Parameters\n",
-      "----------\n",
-      "a : input rank-2 array('d') with bounds (n,n)\n",
-      "b : input rank-1 array('d') with bounds (n)\n",
-      "\n",
-      "Other Parameters\n",
-      "----------------\n",
-      "n : input int, optional\n",
-      "    Default: shape(a, 0)\n",
-      "\n",
-      "Returns\n",
-      "-------\n",
-      "x : rank-1 array('d') with bounds (n)\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(solve.__doc__)"
    ]
@@ -803,7 +631,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "id": "67c73007",
    "metadata": {
     "editable": true,
@@ -812,18 +640,7 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([-0.19565217,  0.47826087])"
-      ]
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "x = np.linalg.solve(A, b)\n",
     "x"
@@ -831,7 +648,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "id": "1fcd6beb-ffad-4787-90fc-683850018b66",
    "metadata": {
     "editable": true,
@@ -896,6 +713,132 @@
   },
   {
    "cell_type": "markdown",
+   "id": "aacd8f07-ac73-4625-a310-11195755b7d1",
+   "metadata": {},
+   "source": [
+    "## Explicit compiler selection\n",
+    "\n",
+    "The ways to explicitly specify the compiler are described in the `f2py` documentation:\n",
+    "- [Pass a compiler name](https://numpy.org/doc/stable/f2py/buildtools/distutils-to-meson.html#pass-a-compiler-name);\n",
+    "- [F2PY and Windows Intel Fortran](https://numpy.org/doc/stable/f2py/windows/intel.html).\n",
+    "\n",
+    "For `meson`, at a minimum, the environment variable `FC` should be defined, but for some compilers it may be necessary to use additional flags and/or environment variables."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0f373791-9a85-4358-b5cd-f0f996efa8fd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import shutil\n",
+    "import sys\n",
+    "\n",
+    "\n",
+    "def restore_fc() -> None:\n",
+    "    if \"_start_restore_fc\" in globals():\n",
+    "        if _start_restore_fc is not None:\n",
+    "            os.environ[\"FC\"] = _start_restore_fc\n",
+    "        else:\n",
+    "            os.environ.pop(\"FC\", None)\n",
+    "\n",
+    "\n",
+    "if \"_start_restore_fc\" not in globals():\n",
+    "    _start_restore_fc = os.environ.get(\"FC\")\n",
+    "restore_fc()\n",
+    "\n",
+    "explicit_fortran_flags = \"\"\n",
+    "for fc in \"ifort\", \"ifx\", \"nvfortran\", \"flang\":\n",
+    "    if shutil.which(fc):\n",
+    "        os.environ[\"FC\"] = fc\n",
+    "        if fc == \"ifort\":\n",
+    "            ifort_path = shutil.which(fc)\n",
+    "            ifort_prefix = os.path.dirname(os.path.dirname(os.path.dirname(ifort_path)))\n",
+    "            explicit_fortran_flags = f\"--extra '-L{ifort_prefix}/compiler/lib'\"\n",
+    "        elif fc == \"nvfortran\":\n",
+    "            nv_path = shutil.which(fc)\n",
+    "            nv_libdir = os.path.dirname(os.path.dirname(nv_path)) + \"/lib\"\n",
+    "            if nv_libdir not in os.environ[\"LD_LIBRARY_PATH\"]:\n",
+    "                print(f\"WARNING: {nv_libdir} not in LD_LIBRARY_PATH\", file=sys.stderr)\n",
+    "            explicit_fortran_flags = f\"--extra '-L{nv_libdir} -lnvf -lnvc'\"\n",
+    "        print(f\"Found {fc}\")\n",
+    "        break\n",
+    "else:\n",
+    "    print(\"Not found ifort, ifx, nvfortran or flang\")\n",
+    "# Need for multiply changes\n",
+    "# %fortran_config --clean-cache"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "21eb216d-6daf-4188-8a8c-5ccd790b261c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%fortran {explicit_fortran_flags}\n",
+    "subroutine explicit_fortran(version)\n",
+    "    use iso_fortran_env\n",
+    "\n",
+    "    character(len=256), intent(out):: version\n",
+    "    version = compiler_version()\n",
+    "end subroutine"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "48004fcf-4add-4d81-ab23-e72387e0ad8a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(explicit_fortran().decode())\n",
+    "with open(\"explicit_fortran.txt\", \"wb\") as f:\n",
+    "    f.write(explicit_fortran())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "76e25741-1861-4e00-9686-19305d95f4ab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "restore_fc()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6ec00178-b34a-4c6d-9ba0-884ce8cf717d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%fortran\n",
+    "subroutine native_fortran(version)\n",
+    "    use iso_fortran_env\n",
+    "\n",
+    "    character(len=256), intent(out):: version\n",
+    "    version = compiler_version()\n",
+    "end subroutine"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0abdccfd-c16a-4815-a485-0076f58d6eae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(native_fortran().decode())\n",
+    "with open(\"native_fortran.txt\", \"wb\") as f:\n",
+    "    f.write(native_fortran())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "82842bda",
    "metadata": {
     "editable": true,
@@ -927,7 +870,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "id": "3786a402",
    "metadata": {
     "editable": true,
@@ -938,16 +881,7 @@
      "random"
     ]
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "New default arguments for %fortran:\n",
-      "\t-vvv --extra '-DNPY_NO_DEPRECATED_API=0'\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%fortran_config -vvv {f_config}"
    ]
@@ -1006,7 +940,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "id": "54480e4b",
    "metadata": {
     "editable": true,
@@ -1015,16 +949,7 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Current defaults arguments for %fortran:\n",
-      "\t-vvv --extra '-DNPY_NO_DEPRECATED_API=0'\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%fortran_config"
    ]
@@ -1045,7 +970,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "id": "1475ba52",
    "metadata": {
     "editable": true,
@@ -1056,16 +981,7 @@
      "slow"
     ]
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Ok. The following fortran objects are ready to use: hi\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%fortran -v\n",
     "\n",
@@ -1090,7 +1006,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "id": "3321871f",
    "metadata": {
     "collapsed": false,
@@ -1103,22 +1019,14 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Deleted custom config. Back to default arguments for %%fortran\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%fortran_config --defaults"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "id": "0be16a46-9ebe-40d5-a130-6dbdd81a13e7",
    "metadata": {
     "editable": true,
@@ -1129,16 +1037,7 @@
      "random"
     ]
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "New default arguments for %fortran:\n",
-      "\t--extra '-DNPY_NO_DEPRECATED_API=0'\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%fortran_config {f_config}"
    ]
@@ -1154,9 +1053,19 @@
     "tags": []
    },
    "source": [
-    "## Help on f2py \n",
+    "## Help on `--link` dependicies option\n",
     "\n",
-    "F2py has some flag that output help. See the docstring of `%f2py_help`"
+    "Currently, for versions of NumPy 2.0.0 and higher and/or\n",
+    "Python 3.12 and higher, the meson build system is used, which\n",
+    "searches for and resolves dependencies in several ways:\n",
+    "`pkg-config`, `CMake find_package`, etc. To select\n",
+    "the `--link` arguments, read the documentation for these packages.\n",
+    "Frequently used dependencies: `blas`, `lapack`, `mkl-sdl`\n",
+    "(MKL, which contains variants of BLAS and LAPACK), `OpenMP`,\n",
+    "`scalapack`.\n",
+    "\n",
+    "Previously, for NumPy versions prior to 1.26.4, `f2py` has some\n",
+    "flag that output help. See the docstring of `%f2py_help`"
    ]
   },
   {
@@ -1205,7 +1114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "id": "d02f8355",
    "metadata": {
     "editable": true,
@@ -1217,15 +1126,7 @@
      "slow"
     ]
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Use --dep for meson builds\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%f2py_help --link lapack"
    ]
@@ -1250,7 +1151,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "id": "acf599f8-245b-4b8e-b582-1e9f6f1f52db",
    "metadata": {
     "editable": true,
@@ -1266,7 +1167,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "id": "beae6740-c9db-40d0-aeae-802d4883403b",
    "metadata": {
     "editable": true,
@@ -1278,16 +1179,7 @@
      "random"
     ]
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The extension _fortran_magic_9d72701d516b1704fe4ad110d877459f is already loaded. To reload it, use:\n",
-      "  %fortran_config --clean-cache\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%fortran\n",
     "\n",
@@ -1302,7 +1194,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "id": "0d7a144d-c857-40c3-99e8-5ecd95ac8f82",
    "metadata": {
     "editable": true,
@@ -1337,7 +1229,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "id": "fa8575a6-01ef-48b1-a243-9ad353965123",
    "metadata": {
     "editable": true,
@@ -1363,7 +1255,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "id": "2a6e2289-8875-48b6-a8cf-e831e1b777a5",
    "metadata": {
     "editable": true,
@@ -1396,7 +1288,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "id": "96b0a47c-dadc-48d3-beda-49c0511622f5",
    "metadata": {
     "editable": true,
@@ -1407,16 +1299,7 @@
      "random"
     ]
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Clean cache: /Users/leo/.cache/ipython/fortranmagic/26beaced\n",
-      "New cache: /Users/leo/.cache/ipython/fortranmagic/64dea1f0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%fortran_config -v --clean-cache"
    ]
@@ -1438,7 +1321,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "id": "8f61fddc-676d-499d-b9f5-2ac9d1b6b744",
    "metadata": {
     "editable": true,
@@ -1447,15 +1330,7 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Overwriting tfone.f90\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%file tfone.f90\n",
     "\n",
@@ -1466,7 +1341,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": null,
    "id": "7fb27b941602401d91542211134fc71a",
    "metadata": {
     "editable": true,
@@ -1484,7 +1359,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": null,
    "id": "7e0eafe3-c8c7-4fd7-ae23-617ad791a9cb",
    "metadata": {
     "editable": true,
@@ -1505,7 +1380,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": null,
    "id": "f3cb72e1-55a3-4242-baa0-02b2053aea94",
    "metadata": {
     "editable": true,
@@ -1517,6 +1392,184 @@
    "outputs": [],
    "source": [
     "assert tfone() == 1 and tfdigits() == 24"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7195b30d-6f80-48b5-8ec3-89aa9d3454dc",
+   "metadata": {},
+   "source": [
+    "# Multithreading"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "61f4a67a-c673-4e4a-a8c4-c8ec6f72def4",
+   "metadata": {},
+   "source": [
+    "## Use OpenMP\n",
+    "\n",
+    "You can use OpenMP, however, in this case you should not\n",
+    "use call-back functions from work threads."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ba5cae37-4358-488e-8d8c-187a8bfea2bc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%fortran --f90flags='-fopenmp' --link openmp\n",
+    "integer function omp_sample(tids)\n",
+    "    use omp_lib\n",
+    "\n",
+    "    integer, intent(out) :: tids(10)\n",
+    "\n",
+    "    integer nid, cid\n",
+    "\n",
+    "    tids(:) = -1\n",
+    "    nid = 0\n",
+    "    !$omp parallel private(cid)\n",
+    "        !$omp critical\n",
+    "            nid = nid + 1\n",
+    "            cid = nid\n",
+    "        !$omp end critical\n",
+    "        if (cid <= size(tids)) then\n",
+    "            tids(cid) = omp_get_thread_num()\n",
+    "        endif\n",
+    "    !$omp end parallel\n",
+    "    omp_sample = nid\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "298c9df1-ad28-4736-8003-17c26d9e55a6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "omp_sample()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8dd00663-4207-4474-85a8-9d6c08e7d418",
+   "metadata": {},
+   "source": [
+    "## Use Python threading\n",
+    "\n",
+    "When using Python threading, by default, `f2py` holds\n",
+    "GIL until it returns from the fortran function. However, this\n",
+    "behavior can be changed by the directive `!f2py threadsafe`.\n",
+    "\n",
+    "Unfortunately, the use of scalar coarrays or coindexed objects\n",
+    "is undocumented, so thread synchronization or control cache\n",
+    "coherence is somewhat difficult."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6f246f15-e5ea-4566-b8e2-c644b928c64d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%fortran\n",
+    "module pt_sample\n",
+    "    use iso_fortran_env\n",
+    "\n",
+    "    integer, parameter :: max_threads = 10\n",
+    "    integer run_thr(max_threads)\n",
+    "    integer max_thr(max_threads)\n",
+    "\n",
+    "    private impl_common\n",
+    "contains\n",
+    "    subroutine impl_common(id)\n",
+    "        integer id\n",
+    "        run_thr(id) = 1\n",
+    "        call sleep(1)\n",
+    "        max_thr(id) = sum(run_thr(:))\n",
+    "        run_thr(id) = 0\n",
+    "    end subroutine\n",
+    "    subroutine pt_native(id)\n",
+    "        integer id\n",
+    "        call impl_common(id)\n",
+    "    end subroutine\n",
+    "    subroutine pt_threadsafe(id)\n",
+    "        !f2py threadsafe\n",
+    "        integer id\n",
+    "        call impl_common(id)\n",
+    "    end subroutine\n",
+    "end module"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4ceb70e8-3214-4ad0-85bd-ee4fa3e8b443",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import threading\n",
+    "\n",
+    "pt_sample.run_thr[:] = 0\n",
+    "pt_sample.max_thr[:] = 0\n",
+    "pt_thrs = [threading.Thread(target=pt_sample.pt_native, args=(i + 1,)) for i in range(pt_sample.max_threads)]\n",
+    "for pt in pt_thrs:\n",
+    "    pt.start()\n",
+    "for pt in pt_thrs:\n",
+    "    pt.join()\n",
+    "pt_sample.max_thr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8ea35b0f-6701-4b75-a527-3d1aef36ec81",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pt_sample.run_thr[:] = 0\n",
+    "pt_sample.max_thr[:] = 0\n",
+    "pt_thrs = [threading.Thread(target=pt_sample.pt_threadsafe, args=(i + 1,)) for i in range(pt_sample.max_threads)]\n",
+    "for pt in pt_thrs:\n",
+    "    pt.start()\n",
+    "for pt in pt_thrs:\n",
+    "    pt.join()\n",
+    "pt_sample.max_thr"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "366e1275-a064-40c9-b914-7935f45779d8",
+   "metadata": {},
+   "source": [
+    "## Free-threaded Python\n",
+    "\n",
+    "As a result of the migration process from GIL to Free-threaded\n",
+    "Python, warnings containing the following content may appear when\n",
+    "loading modules (cells)::\n",
+    "```\n",
+    "<frozen importlib._bootstrap>:491: RuntimeWarning: The global\n",
+    "interpreter lock (GIL) has been enabled to load module 'fib1',\n",
+    "which has not declared that it can run safely without the GIL.\n",
+    "To override this behavior and keep the GIL disabled (at your\n",
+    "own risk), run with PYTHON_GIL=0 or -Xgil=0.\n",
+    "```\n",
+    "\n",
+    "If the code in the thread cell is safe, it can be removed with\n",
+    "the option (`NumPY` 2.1 or higher):\n",
+    "```\n",
+    "%%fortran --extra '--freethreading-compatible'\n",
+    "```\n",
+    "\n",
+    "If the code in the entire notebook is thread-safe, then you can\n",
+    "use (`NumPY` 2.1 or higher):\n",
+    "```\n",
+    "%fortran_config --extra '--freethreading-compatible'\n",
+    "```"
    ]
   },
   {

--- a/fortranmagic.py
+++ b/fortranmagic.py
@@ -27,7 +27,7 @@ from IPython.paths import get_ipython_cache_dir
 from IPython.utils.io import capture_output
 from numpy.f2py import f2py2e
 
-__version__ = "1.0.0a2"
+__version__ = "1.0"
 _VERBOSITY_DEBUG = 2
 
 

--- a/prek.toml
+++ b/prek.toml
@@ -1,0 +1,29 @@
+[[repos]]
+repo = "https://github.com/pre-commit/pre-commit-hooks"
+rev = "v6.0.0"
+hooks = [
+  { id = "trailing-whitespace" },
+  { id = "end-of-file-fixer" },
+  { id = "check-yaml" },
+  { id = "check-toml" },
+  { id = "check-merge-conflict" },
+]
+
+[[repos]]
+repo = "local"
+
+[[repos.hooks]]
+id = "ruff-check"
+name = "ruff check"
+language = "system"
+entry = "uv run --group dev ruff check ."
+pass_filenames = false
+always_run = true
+
+[[repos.hooks]]
+id = "ruff-format"
+name = "ruff format"
+language = "system"
+entry = "uv run --group dev ruff format --check ."
+pass_filenames = false
+always_run = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,9 @@ build-backend = "hatchling.build"
 [project]
 name = "fortran-magic"
 dynamic = ["version"]
-description = "An extension for IPython that help to use Fortran in your interactive session."
+description = "An IPython extension for compiling and using Fortran code interactively."
 readme = "README.md"
-requires-python = ">=3.10,<3.15"
+requires-python = ">=3.10,<3.16"
 license = { file = "LICENSE" }
 authors = [
   { name = "Martin Gaitan", email = "gaitan@gmail.com" },
@@ -28,6 +28,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: 3.15",
   "Programming Language :: Fortran",
   "Topic :: Software Development :: Libraries :: Python Modules",
   "Topic :: Scientific/Engineering",
@@ -35,8 +36,10 @@ classifiers = [
 
 [project.urls]
 Homepage = "https://github.com/mgaitan/fortran_magic"
-Documentation = "http://nbviewer.ipython.org/urls/raw.github.com/mgaitan/fortran_magic/master/documentation.ipynb"
+Documentation = "https://nbviewer.org/github/mgaitan/fortran_magic/blob/master/documentation.ipynb"
 Changelog = "https://github.com/mgaitan/fortran_magic/blob/master/CHANGES.md"
+Repository = "https://github.com/mgaitan/fortran_magic"
+Issues = "https://github.com/mgaitan/fortran_magic/issues"
 
 [dependency-groups]
 dev = [
@@ -71,7 +74,7 @@ include = [
 include = ["fortranmagic.py"]
 
 [tool.pytest.ini_options]
-addopts = "-m \"not paranoid\""
+addopts = ["-m", "not paranoid", "--strict-markers", "--strict-config", "-ra"]
 markers = [
   "fast: test only cells with tags 'fast'",
   "medium: test untagged cells and with tags 'fast'",
@@ -117,3 +120,6 @@ select = [
 "documentation.ipynb" = ["F821", "PLR2004"]
 "fortranmagic.py" = ["ANN", "C901", "PLR0912", "PLR0915", "TRY003"]
 "tests/*.py" = ["ANN", "C901", "PLR0912", "PLR0915", "PLR2004", "PLC0415", "PLW0603"]
+
+[tool.uv]
+exclude-newer = "1 week"

--- a/tests/base-environment.yml
+++ b/tests/base-environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - yamllint
   - pytest
   - pytest-cov
-  - uv
+  # - uv                  # use external install for caching
   - meson
   - ninja
   - cmake

--- a/tests/test_f2py.py
+++ b/tests/test_f2py.py
@@ -50,6 +50,10 @@ def test_f2py_command(numpy_correct_compilers) -> None:
     https://numpy.org/doc/stable/f2py/f2py.getting-started.html#
     """
 
+    # FIXME: may be add "--freethreading-compatible" to
+    # `numpy_correct_compilers`, but `numpy_correct_compilers` seems broken
+    freethreading_compatible = ["--freethreading-compatible"] if np.lib.NumpyVersion(np.__version__) >= "2.1.0" else []
+
     tdir = "tests"
     mod = "fib1"
     ret = subprocess.check_call(
@@ -63,6 +67,7 @@ def test_f2py_command(numpy_correct_compilers) -> None:
             tdir + "/" + mod + ".f",
             "-m",
             mod,
+            *freethreading_compatible,
             *numpy_correct_compilers,
         ]
     )

--- a/tests/test_fortran_config.py
+++ b/tests/test_fortran_config.py
@@ -12,6 +12,7 @@ import warnings
 
 import IPython.core.interactiveshell as ici
 import IPython.paths
+import numpy as np
 import pytest
 
 pytestmark = pytest.mark.requires_fortran
@@ -74,6 +75,11 @@ class Cish:
         """Call `%fortran_config` and check success."""
 
         if flgs is not None:
+            # FIXME: may be add "--freethreading-compatible" to
+            # `numpy_correct_compilers`, but `numpy_correct_compilers` seems
+            # broken
+            if np.lib.NumpyVersion(np.__version__) >= "2.1.0":
+                flgs = "--extra '--freethreading-compatible'" + " " + flgs
             if self.numpy_correct_compilers:
                 flgs = self.numpy_correct_compilers + " " + flgs
             elif not flgs:

--- a/tests/test_readme_md.py
+++ b/tests/test_readme_md.py
@@ -51,5 +51,7 @@ def test_ipython_cells() -> None:
         if "Out" in c:
             np.testing.assert_allclose(float("\n".join(cells[-1]["Out"])), float(er.result))
             checked += 1
+        if c["In"][0].startswith("%load_ext") and np.lib.NumpyVersion(np.__version__) >= "2.1.0":
+            ish.run_cell("%fortran_config --extra '--freethreading-compatible'", store_history=False)
 
     assert success > 0 and checked > 0


### PR DESCRIPTION
## Summary

- modernize CI, publishing, local QA, and project metadata following the package template
- support and test Python 3.15, including free-threaded f2py configuration
- update the notebook for stable installation, current nbviewer URLs, Meson linking, and explicit compiler selection

Closes #17
Closes #50
Closes #52
Closes #55

## Verification

- `prek run --all-files`
- `JUPYTER_PLATFORM_DIRS=1 uv run --group dev pytest`
- `uv build`

`#41` remains open: persistent compiled-module reuse needs separate ABI and dependency validation.