### PR TITLE
chore: modernize packaging and release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@
 # vim:set sw=2 ts=8 et fileencoding=utf8:
 # SPDX-License-Identifier: BSD-3-Clause
 #
-name: Publish Python 🐍 distributions 📦 to PyPI
+name: Publish to PyPI
 
 on:  # yamllint disable-line rule:truthy
   release:
@@ -13,11 +13,12 @@ jobs:
     name: upload release to PyPI
     runs-on: ubuntu-latest
     permissions:
-      # IMPORTANT: this permission is mandatory for trusted publishing
+      contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v7
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8.2.0
       - run: uv build
-      - if: github.event_name == 'release'
-        run: uv publish
+      - name: Generate publish attestations
+        uses: astral-sh/attest-action@f589a42a7efb6fe400b4f400de60b4bc90390027 # v0.0.6
+      - run: uv publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,5 +20,6 @@ jobs:
       - uses: astral-sh/setup-uv@v8.2.0
       - run: uv build
       - name: Generate publish attestations
-        uses: astral-sh/attest-action@f589a42a7efb6fe400b4f400de60b4bc90390027 # v0.0.6
+        # v0.0.6
+        uses: astral-sh/attest-action@f589a42a7efb6fe400b4f400de60b4bc90390027
       - run: uv publish

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,8 +4,7 @@
 
 - Switch packaging to `pyproject.toml` with Hatchling and embed pytest config.
 - Drop legacy distutils backend and require Meson for f2py builds.
-- Support Python 3.10 through 3.14 (3.15 ready, CI tests for 3.15.0b1 or
-  above).
+- Support Python 3.10 through 3.14.
 - Convert README and changelog to Markdown.
 - Update release automation to build/publish with `uv`.
 - Stabilize IPython cache handling and test isolation.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,11 @@
 # Changelog
 
-## 1.0 / 2025-12-24
+## 1.0 / 2026-05-10
 
 - Switch packaging to `pyproject.toml` with Hatchling and embed pytest config.
 - Drop legacy distutils backend and require Meson for f2py builds.
-- Support Python 3.10 through 3.14.
+- Support Python 3.10 through 3.14 (3.15 ready, CI tests for 3.15.0b1 or
+  above).
 - Convert README and changelog to Markdown.
 - Update release automation to build/publish with `uv`.
 - Stabilize IPython cache handling and test isolation.
@@ -15,8 +16,11 @@
 - Fix README test parser edge case for missing prefixes.
 - Direct dependencies on meson and ninja simplify installation and
   configuration.
-- The ability to open and try the documentation notebook in Google
-  Colab or GitHub Codespace without a local installation.
+- The ability to open and try the documentation notebook in Google Colab or
+  GitHub Codespace without a local installation.
+- Fix documentation for free-threading Python.
+- Fix documentation for `meson` semantics of the `--link` option.
+- Fix CI for Node24.js.
 
 ## 0.9 / 2024-05-27
 

--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,13 @@ export UV_MALWARE_CHECK := 1
 
 install:
 	uv sync
-	prek install
+	uv run --group dev prek install
 
 test:
 	JUPYTER_PLATFORM_DIRS=1 uv run --group dev pytest
 
 qa:
-	prek run --all-files
+	uv run --group dev prek run --all-files
 
 build:
 	uv build

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY: install test qa build
+
+export UV_MALWARE_CHECK := 1
+
+install:
+	uv sync
+	prek install
+
+test:
+	JUPYTER_PLATFORM_DIRS=1 uv run --group dev pytest
+
+qa:
+	prek run --all-files
+
+build:
+	uv build

--- a/fortranmagic.py
+++ b/fortranmagic.py
@@ -27,7 +27,7 @@ from IPython.paths import get_ipython_cache_dir
 from IPython.utils.io import capture_output
 from numpy.f2py import f2py2e
 
-__version__ = "1.0.0a2"
+__version__ = "1.0"
 _VERBOSITY_DEBUG = 2
 
 

--- a/prek.toml
+++ b/prek.toml
@@ -1,0 +1,29 @@
+[[repos]]
+repo = "https://github.com/pre-commit/pre-commit-hooks"
+rev = "v6.0.0"
+hooks = [
+  { id = "trailing-whitespace" },
+  { id = "end-of-file-fixer" },
+  { id = "check-yaml" },
+  { id = "check-toml" },
+  { id = "check-merge-conflict" },
+]
+
+[[repos]]
+repo = "local"
+
+[[repos.hooks]]
+id = "ruff-check"
+name = "ruff check"
+language = "system"
+entry = "uv run --group dev ruff check ."
+pass_filenames = false
+always_run = true
+
+[[repos.hooks]]
+id = "ruff-format"
+name = "ruff format"
+language = "system"
+entry = "uv run --group dev ruff format --check ."
+pass_filenames = false
+always_run = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "fortran-magic"
 dynamic = ["version"]
 description = "An IPython extension for compiling and using Fortran code interactively."
 readme = "README.md"
-requires-python = ">=3.10,<3.15"
+requires-python = ">=3.10,<3.16"
 license = { file = "LICENSE" }
 authors = [
   { name = "Martin Gaitan", email = "gaitan@gmail.com" },
@@ -28,6 +28,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: 3.15",
   "Programming Language :: Fortran",
   "Topic :: Software Development :: Libraries :: Python Modules",
   "Topic :: Scientific/Engineering",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "fortran-magic"
 dynamic = ["version"]
-description = "An extension for IPython that help to use Fortran in your interactive session."
+description = "An IPython extension for compiling and using Fortran code interactively."
 readme = "README.md"
 requires-python = ">=3.10,<3.16"
 license = { file = "LICENSE" }
@@ -36,8 +36,10 @@ classifiers = [
 
 [project.urls]
 Homepage = "https://github.com/mgaitan/fortran_magic"
-Documentation = "http://nbviewer.ipython.org/urls/raw.github.com/mgaitan/fortran_magic/master/documentation.ipynb"
+Documentation = "https://nbviewer.org/github/mgaitan/fortran_magic/blob/master/documentation.ipynb"
 Changelog = "https://github.com/mgaitan/fortran_magic/blob/master/CHANGES.md"
+Repository = "https://github.com/mgaitan/fortran_magic"
+Issues = "https://github.com/mgaitan/fortran_magic/issues"
 
 [dependency-groups]
 dev = [
@@ -72,7 +74,7 @@ include = [
 include = ["fortranmagic.py"]
 
 [tool.pytest.ini_options]
-addopts = "-m \"not paranoid\""
+addopts = ["-m", "not paranoid", "--strict-markers", "--strict-config", "-ra"]
 markers = [
   "fast: test only cells with tags 'fast'",
   "medium: test untagged cells and with tags 'fast'",
@@ -118,3 +120,6 @@ select = [
 "documentation.ipynb" = ["F821", "PLR2004"]
 "fortranmagic.py" = ["ANN", "C901", "PLR0912", "PLR0915", "TRY003"]
 "tests/*.py" = ["ANN", "C901", "PLR0912", "PLR0915", "PLR2004", "PLC0415", "PLW0603"]
+
+[tool.uv]
+exclude-newer = "1 week"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "fortran-magic"
 dynamic = ["version"]
 description = "An IPython extension for compiling and using Fortran code interactively."
 readme = "README.md"
-requires-python = ">=3.10,<3.16"
+requires-python = ">=3.10,<3.15"
 license = { file = "LICENSE" }
 authors = [
   { name = "Martin Gaitan", email = "gaitan@gmail.com" },
@@ -28,7 +28,6 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
-  "Programming Language :: Python :: 3.15",
   "Programming Language :: Fortran",
   "Topic :: Software Development :: Libraries :: Python Modules",
   "Topic :: Scientific/Engineering",
@@ -51,6 +50,7 @@ dev = [
   "ninja",
   "pickleshare",
   "pytest",
+  "prek",
   "ruff",
   "tomli; python_version < '3.11'",
   "cmake",


### PR DESCRIPTION
## Summary

- prepare the package metadata and version for stable 1.0
- add Makefile and prek-based local QA following the package template
- modernize trusted publishing and generate publish attestations

## Verification

- `prek run --all-files`
- `JUPYTER_PLATFORM_DIRS=1 uv run --group dev pytest`
- `uv build`